### PR TITLE
Issue #85: Fix bug where detected sculk sensor clocks were broken but not dropped

### DIFF
--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/RedstoneClockService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/RedstoneClockService.java
@@ -10,7 +10,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -169,7 +171,9 @@ public final class RedstoneClockService {
     private void breakBlock(@NotNull Location location) {
         Block block = location.getBlock();
         if (this.dropItems) {
-            var drops = block.getDrops();
+            ItemStack destroyTool = new ItemStack(Material.DIAMOND_PICKAXE);
+            destroyTool.addEnchantment(Enchantment.SILK_TOUCH, 1);
+            var drops = block.getDrops(destroyTool);
             drops.forEach(itemStack -> block.getWorld().dropItem(location, itemStack));
         }
         Runnable removeTask = () -> block.setType(Material.AIR, true);

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/RedstoneClockService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/RedstoneClockService.java
@@ -35,6 +35,7 @@ public final class RedstoneClockService {
     private List<String> ignoredWorlds;
 
     private final ConcurrentHashMap<Location, RedstoneClock> activeClockTesters = new ConcurrentHashMap<>();
+    private final ItemStack SILK_TOUCH_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
 
     public RedstoneClockService(@NotNull AntiRedstoneClockRemastered antiRedstoneClockRemastered) {
         this.antiRedstoneClockRemastered = antiRedstoneClockRemastered;
@@ -45,6 +46,7 @@ public final class RedstoneClockService {
         this.notifyConsole = antiRedstoneClockRemastered.getConfig().getBoolean("clock.notifyConsole", true);
         this.dropItems = antiRedstoneClockRemastered.getConfig().getBoolean("clock.drop", false);
         this.ignoredWorlds = antiRedstoneClockRemastered.getConfig().getStringList("check.ignoredWorlds");
+        SILK_TOUCH_PICKAXE.addEnchantment(Enchantment.SILK_TOUCH, 1);
     }
 
     public void checkAndUpdateClockStateWithActiveManual(@NotNull Location location, boolean state) {
@@ -171,9 +173,7 @@ public final class RedstoneClockService {
     private void breakBlock(@NotNull Location location) {
         Block block = location.getBlock();
         if (this.dropItems) {
-            ItemStack destroyTool = new ItemStack(Material.DIAMOND_PICKAXE);
-            destroyTool.addEnchantment(Enchantment.SILK_TOUCH, 1);
-            var drops = block.getDrops(destroyTool);
+            var drops = block.getDrops(SILK_TOUCH_PICKAXE);
             drops.forEach(itemStack -> block.getWorld().dropItem(location, itemStack));
         }
         Runnable removeTask = () -> block.setType(Material.AIR, true);


### PR DESCRIPTION
<!--
MIT License

Copyright (c) 2022 Marketing Pipeline

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
-->

## Proposed changes

Fixes #85 

Previously, whenever the plugin detected a clock using sculk sensors, it would destroy the sculk sensors but not drop them. This was because sculk sensors can only drop if you destroy them using a 'Silk Touch'-enchanted tool. Hence why I propose to set it when determining the dropped items in the getDrops() function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)