### PR TITLE
Fix 1.20.6 translation support

### DIFF
--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/api/TranslationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/api/TranslationService.java
@@ -1,0 +1,14 @@
+package net.onelitefeather.antiredstoneclockremastered.service.api;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public interface TranslationService {
+
+    void registerAll(final @NotNull Locale locale, final @NotNull ResourceBundle bundle, final boolean escapeSingleQuotes);
+
+    void registerGlobal();
+
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/impl/LegacyTranslationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/impl/LegacyTranslationService.java
@@ -1,0 +1,32 @@
+package net.onelitefeather.antiredstoneclockremastered.service.impl;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationRegistry;
+import net.onelitefeather.antiredstoneclockremastered.service.api.TranslationService;
+import net.onelitefeather.antiredstoneclockremastered.translations.PluginTranslationRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+@Deprecated(since = "2.0.13", forRemoval = true)
+public final class LegacyTranslationService implements TranslationService {
+
+    private final TranslationRegistry translationRegistry;
+
+    public LegacyTranslationService() {
+        this.translationRegistry = new PluginTranslationRegistry(TranslationRegistry.create(Key.key("antiredstoneclockremastered", "translations")));
+        this.translationRegistry.defaultLocale(Locale.US);
+    }
+
+    @Override
+    public void registerAll(@NotNull Locale locale, @NotNull ResourceBundle bundle, boolean escapeSingleQuotes) {
+        this.translationRegistry.registerAll(locale, bundle, escapeSingleQuotes);
+    }
+
+    @Override
+    public void registerGlobal() {
+        GlobalTranslator.translator().addSource(this.translationRegistry);
+    }
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/impl/ModernTranslationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/impl/ModernTranslationService.java
@@ -1,0 +1,30 @@
+package net.onelitefeather.antiredstoneclockremastered.service.impl;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.minimessage.translation.MiniMessageTranslationStore;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.onelitefeather.antiredstoneclockremastered.service.api.TranslationService;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public final class ModernTranslationService implements TranslationService {
+
+    private final MiniMessageTranslationStore miniMessageTranslationStore;
+
+    public ModernTranslationService() {
+        this.miniMessageTranslationStore = MiniMessageTranslationStore.create(Key.key("antiredstoneclockremastered", "translations"));
+        this.miniMessageTranslationStore.defaultLocale(Locale.US);
+    }
+
+    @Override
+    public void registerAll(@NotNull Locale locale, @NotNull ResourceBundle bundle, boolean escapeSingleQuotes) {
+        this.miniMessageTranslationStore.registerAll(locale, bundle, escapeSingleQuotes);
+    }
+
+    @Override
+    public void registerGlobal() {
+        GlobalTranslator.translator().addSource(this.miniMessageTranslationStore);
+    }
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/translations/PluginTranslationRegistry.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/translations/PluginTranslationRegistry.java
@@ -1,0 +1,125 @@
+package net.onelitefeather.antiredstoneclockremastered.translations;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.translation.TranslationRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class PluginTranslationRegistry implements TranslationRegistry {
+
+    private final TranslationRegistry backedRegistry;
+
+    public PluginTranslationRegistry(TranslationRegistry backedRegistry) {
+        this.backedRegistry = backedRegistry;
+    }
+
+    @Override
+    public boolean contains(@NotNull String key) {
+        return backedRegistry.contains(key);
+    }
+
+    @Override
+    public boolean contains(@NotNull String key, @NotNull Locale locale) {
+        return backedRegistry.contains(key, locale);
+    }
+
+    @Override
+    public @NotNull Key name() {
+        return backedRegistry.name();
+    }
+
+    @Override
+    public @Nullable MessageFormat translate(@NotNull String key, @NotNull Locale locale) {
+        return null;
+    }
+
+    @Override
+    public @Nullable Component translate(
+            @NotNull TranslatableComponent component,
+            @NotNull Locale locale
+    ) {
+        final MessageFormat translationFormat = backedRegistry.translate(component.key(), locale);
+
+        if (translationFormat == null) {
+            return null;
+        }
+
+        final String miniMessageString = translationFormat.toPattern();
+
+        final Component resultingComponent;
+
+        if (component.arguments().isEmpty()) {
+            resultingComponent = MiniMessage.miniMessage().deserialize(miniMessageString);
+        } else {
+            resultingComponent = MiniMessage.miniMessage().deserialize(miniMessageString,
+                    new ArgumentTag(component.arguments()));
+        }
+
+        if (component.children().isEmpty()) {
+            return resultingComponent;
+        } else {
+            return resultingComponent.children(component.children());
+        }
+    }
+
+    @Override
+    public void defaultLocale(@NotNull Locale locale) {
+        backedRegistry.defaultLocale(locale);
+    }
+
+    @Override
+    public void register(@NotNull String key, @NotNull Locale locale, @NotNull MessageFormat format) {
+        backedRegistry.register(key, locale, format);
+    }
+
+    @Override
+    public void unregister(@NotNull String key) {
+        backedRegistry.unregister(key);
+    }
+
+    private static final class ArgumentTag implements TagResolver {
+        private static final String NAME = "argument";
+        private static final String NAME_1 = "arg";
+
+        private final List<? extends ComponentLike> argumentComponents;
+
+        private ArgumentTag(final @NotNull  List<? extends ComponentLike> argumentComponents) {
+            this.argumentComponents = Objects.requireNonNull(argumentComponents, "argumentComponents");
+        }
+
+        @Override
+        public Tag resolve(
+                final @NotNull String name,
+                final @NotNull ArgumentQueue arguments,
+                final @NotNull Context ctx
+        ) throws ParsingException {
+            final int index = arguments.popOr("No argument number provided")
+                    .asInt().orElseThrow(() -> ctx.newException("Invalid argument number", arguments));
+
+            if (index < 0 || index >= argumentComponents.size()) {
+                throw ctx.newException("Invalid argument number", arguments);
+            }
+
+            return Tag.inserting(argumentComponents.get(index));
+        }
+
+        @Override
+        public boolean has(final @NotNull String name) {
+            return name.equals(NAME) || name.equals(NAME_1);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Added Service layer for translation service
- Implement Modern and Legacy translation implementation
- Improve loading of translations and change default behavior for loading translations

**Is the translation in the `lang` folder or in the `resources` folder? The `lang` folder is now preferred. If the translation not in the `lang` folder, it will be loaded from the `resources` folder out of jar file.**

The `lang` folder is now default created on if not exists.

Fixes #144

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

If a user has custom translation, they just need to add the translation into the `lang` folder and into the `config.yml` file into `translations` section.

The translation file must be follow the naming convention `antiredstoneclockremasterd_XX-YY.yml` where `XX` is the language code and `YY` is the country code. For example, `antiredstoneclockremasterd_de-DE.yml` for German (Germany).

Here an example config.yml snippet:
```yaml
translations:
  - lang: de-DE
  - lang: fr-FR
  - lang: es-ES
## Other configuration options
```