### PR TITLE
Update paper version to 26.1.2 and multiple changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,12 @@ val supportedMinecraftVersions = listOf(
     "1.21.7",
     "1.21.8",
     "1.21.9",
-    "1.21.10"
+    "1.21.10",
+    "1.21.11",
+    "26.0",
+    "26.1",
+    "26.1.1",
+    "26.1.2"
 )
 allprojects {
     apply {
@@ -46,7 +51,7 @@ allprojects {
 
     configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,12 +18,12 @@ dependencyResolutionManagement {
         create("libs") {
             version("modrinth", "2.+")
             version("hangar", "0.1.4")
-            version("paper.yml", "0.6.0")
+            version("paper.yml", "0.9.0")
             version("paper.run", "3.0.2")
             version("shadowJar", "9.6.0")
             version("cyclonedx", "3.3.0")
 
-            version("paper", "1.21.8-R0.1-SNAPSHOT")
+            version("paper", "26.1.2.build.+")
             version("bstats", "3.2.1")
             version("customblockdata", "2.2.5")
 
@@ -91,7 +91,7 @@ dependencyResolutionManagement {
 
             plugin("modrinth", "com.modrinth.minotaur").versionRef("modrinth")
             plugin("hangar", "io.papermc.hangar-publish-plugin").versionRef("hangar")
-            plugin("paper.yml", "net.minecrell.plugin-yml.paper").versionRef("paper.yml")
+            plugin("paper.yml", "de.eldoria.plugin-yml.paper").versionRef("paper.yml")
             plugin("paper.run", "xyz.jpenilla.run-paper").versionRef("paper.run")
             plugin("shadowJar", "com.gradleup.shadow").versionRef("shadowJar")
             plugin("cyclonedx", "org.cyclonedx.bom").versionRef("cyclonedx")


### PR DESCRIPTION
## Proposed changes

*This PR needs feature testing before merging!* 
Multiple changes:
- Bump paper version to 26.1.2+
- Implement pagination feature to be ready for adventure 5 (still 4, but we need it as it will be thrown out from the dependency)
- Bump java version to 25 for Minecraft 26+
- Update dependencies (worldguard and plotsquared for example)
- more dependency updates will be done by Renovate hopefully, pagination was missing.
- change plugin.yml repository to eldoria because the minecrell dependency is eol.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Server starts fine, plugin did not throw errors but features needs to be checked. Adventure pagination change worked, no errors yet.