### PR TITLE
fix(build): relocate shaded kotlin and okhttp packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,12 @@ tasks {
         archiveClassifier.set("")
         relocate("org.bstats", "net.onelitefeather.antiredstoneclockremastered.org.bstats")
         relocate("com.jeff_media.customblockdata", "net.onelitefeather.antiredstoneclockremastered.com.jeff_media.customblockdata")
+        // Pulled in transitively by club.minnced:discord-webhooks -> okhttp -> kotlin-stdlib.
+        // An unrelocated kotlin/ package makes eco flag this plugin as conflicting (#216).
+        relocate("kotlin", "net.onelitefeather.antiredstoneclockremastered.kotlin")
+        relocate("kotlinx", "net.onelitefeather.antiredstoneclockremastered.kotlinx")
+        relocate("okhttp3", "net.onelitefeather.antiredstoneclockremastered.okhttp3")
+        relocate("okio", "net.onelitefeather.antiredstoneclockremastered.okio")
         dependsOn(jar)
     }
     this.modrinth {


### PR DESCRIPTION
Closes #216

## Problem

eco warns on every server start:

```
[eco] AntiRedstoneClock-Remastered will likely conflict with eco! Reason: Kotlin shaded into jar
```

The plugin is pure Java, but pulls Kotlin in transitively:

```
club.minnced:discord-webhooks:0.8.4
  └── com.squareup.okhttp3:okhttp:4.10.0
        ├── org.jetbrains.kotlin:kotlin-stdlib:1.6.20
        └── com.squareup.okio:okio:3.0.0 → kotlin-stdlib-jdk8:1.5.31
```

These ended up unrelocated in the shadow jar — 1266 entries under `kotlin/`, plus `okhttp3/` and `okio/` at top level.

`ConflictFinder.kt` in [Auxilor/eco](https://github.com/Auxilor/eco/blob/master/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/ConflictFinder.kt) scans every plugin jar and reports `KOTLIN_SHADE` as soon as an entry starts with `kotlin/` or `kotlinx/`:

```kotlin
if (entry.name.startsWith("kotlin/") || entry.name.startsWith("kotlinx/")) {
    return Conflict(this, ConflictType.KOTLIN_SHADE)
}
```

## Fix

The affected packages are relocated in the `shadowJar` task — the same way `org.bstats` and `com.jeff_media.customblockdata` already are. No application code is touched.

`okhttp3` and `okio` are included because they belong to the same dependency chain and, as top-level packages, can collide with other plugins as well.

## Verification

Built with `./gradlew shadowJar` and checked the jar contents against eco's criterion:

| Check | before | after |
|---|---|---|
| Entries with prefix `kotlin/` or `kotlinx/` | 1266 | **0** |
| Top-level packages | `… kotlin, okhttp3, okio …` | none of them |
| Kotlin classes under the plugin package | 0 | 1260 |
| Total classes in the jar | 5737 | 5737 |

In addition, all 1357 classes of the relocated packages (`kotlin`, `okhttp3`, `okio`, `club.minnced`) were loaded with resolution enabled in an isolated JVM: 1356 load cleanly, with no relocation-related linkage error.

The single load failure is `ConscryptPlatform$DisabledHostnameVerifier` → `org/conscrypt/ConscryptHostnameVerifier`. Conscrypt is an optional dependency that okhttp loads reflectively inside a try/catch, and it was absent from the old jar too — not a regression.

The `publicsuffixes.gz` resource was relocated along with its class and still sits relative to `PublicSuffixDatabase`, so the `getResourceAsStream` lookup keeps working unchanged.

## Note (out of scope for this PR)

While inspecting the jar it turned out that `org/slf4j/` and `org/json/` also ship unrelocated. `org.slf4j` is provided by Paper and is a potential conflict candidate. That is a separate topic and deliberately left out here.