### PR TITLE
feat: detect hopper clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For Minecraft version 1.20, it would be 1.20.6 and so on
 - 1.20,1.21 ready
 - Clock detection
 - Sculk support
+- Hopper clock detection
 - Config Migration(Soon)
 - Prevent duplicated loading of anti-redstoneclock plugins
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,6 +198,7 @@ paper {
         register("antiredstoneclockremastered.command.feature.check.piston")
         register("antiredstoneclockremastered.command.feature.check.sculk")
         register("antiredstoneclockremastered.command.feature.check.redstone_and_repeater")
+        register("antiredstoneclockremastered.command.feature.check.hopper")
         register("antiredstoneclockremastered.command.feature.check.world.add")
         register("antiredstoneclockremastered.command.feature.check.world.remove")
         register("antiredstoneclockremastered.command.feature.check.region.remove")
@@ -218,6 +219,7 @@ paper {
                 "antiredstoneclockremastered.command.feature.check.piston",
                 "antiredstoneclockremastered.command.feature.check.sculk",
                 "antiredstoneclockremastered.command.feature.check.redstone_and_repeater",
+                "antiredstoneclockremastered.command.feature.check.hopper",
                 "antiredstoneclockremastered.command.feature.check.world.add",
                 "antiredstoneclockremastered.command.feature.check.world.remove",
                 "antiredstoneclockremastered.command.feature.check.region.remove",

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/FeatureCommand.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/FeatureCommand.java
@@ -73,6 +73,16 @@ public final class FeatureCommand {
         sendMessageToggleMessage(sender, plugin.getConfig().getBoolean("check.sculk"));
     }
 
+    @Command("check hopper")
+    @CommandDescription("antiredstoneclockremastered.command.feature.check.toggle.hopper.description")
+    @Permission("antiredstoneclockremastered.command.feature.check.hopper")
+    public void toggleHopper(CommandSender sender) {
+        plugin.getConfig().set("check.hopper", !plugin.getConfig().getBoolean("check.hopper"));
+        plugin.saveConfig();
+        decisionService.reload();
+        sendMessageToggleMessage(sender, plugin.getConfig().getBoolean("check.hopper"));
+    }
+
     @Command("check redstone_and_repeater")
     @CommandDescription("antiredstoneclockremastered.command.feature.check.toggle.redstone_and_repeater.description")
     @Permission("antiredstoneclockremastered.command.feature.check.redstone_and_repeater")

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ListenerModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ListenerModule.java
@@ -22,6 +22,7 @@ public final class ListenerModule extends AbstractModule {
         bind(ObserverListener.class);
         bind(SculkListener.class);
         bind(PistonListener.class);
+        bind(HopperListener.class);
     }
     
     /**
@@ -48,6 +49,7 @@ public final class ListenerModule extends AbstractModule {
             plugin.getServer().getPluginManager().registerEvents(injector.getInstance(SculkListener.class), plugin);
         }
         plugin.getServer().getPluginManager().registerEvents(injector.getInstance(PistonListener.class), plugin);
+        plugin.getServer().getPluginManager().registerEvents(injector.getInstance(HopperListener.class), plugin);
 
         // Material-dependent listeners now use dependency injection
         var comparator = Material.getMaterial("COMPARATOR");

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/listener/HopperListener.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/listener/HopperListener.java
@@ -1,0 +1,68 @@
+package net.onelitefeather.antiredstoneclockremastered.listener;
+
+import jakarta.inject.Inject;
+import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
+import net.onelitefeather.antiredstoneclockremastered.service.api.DecisionService;
+import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
+import net.onelitefeather.antiredstoneclockremastered.service.tracking.HopperClockTracker;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+
+/**
+ * Listener for handling hopper clocks.
+ *
+ * <p>Two hoppers pointing at each other move the same item back and forth, which keeps the
+ * server busy without any redstone being involved. Only such a change of direction is
+ * reported, so hopper chains of sorting systems are not counted as clocks.</p>
+ *
+ * @author OneLiteFeather
+ * @version 1.0.0
+ * @since 2.9.0
+ */
+public final class HopperListener implements Listener {
+
+    private final AntiRedstoneClockRemastered plugin;
+    private final DecisionService decisionService;
+    private final HopperClockTracker tracker;
+
+    @Inject
+    public HopperListener(AntiRedstoneClockRemastered plugin, DecisionService decisionService) {
+        this.plugin = plugin;
+        this.decisionService = decisionService;
+        this.tracker = new HopperClockTracker();
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    private void onInventoryMoveItem(InventoryMoveItemEvent inventoryMoveItemEvent) {
+        // This event fires for every single item movement on the server, so bail out as early as possible.
+        // The same check runs in SkipEventTypeRedstoneClockMiddleware, this one only saves the chain call.
+        if (!this.plugin.getConfig().getBoolean("check.hopper")) return;
+
+        var sourceLocation = inventoryMoveItemEvent.getSource().getLocation();
+        if (sourceLocation == null || sourceLocation.getBlock().getType() != Material.HOPPER) return;
+
+        var destinationLocation = inventoryMoveItemEvent.getDestination().getLocation();
+        if (destinationLocation == null || destinationLocation.getBlock().getType() != Material.HOPPER) return;
+
+        var sourceKey = HopperClockTracker.keyOf(sourceLocation);
+        var destinationKey = HopperClockTracker.keyOf(destinationLocation);
+        if (sourceKey == null || destinationKey == null) return;
+
+        var timeout = this.plugin.getConfig().getInt("clock.endDelay", 300);
+        if (!this.tracker.registerMovement(sourceKey, destinationKey, System.currentTimeMillis() / 1000, timeout)) {
+            return;
+        }
+
+        // Always report the same hopper of the pair, otherwise every cycle would be tracked as its own clock.
+        var pair = HopperClockTracker.HopperPair.of(sourceKey, destinationKey);
+        var clockBlock = pair.first().equals(sourceKey)
+                ? sourceLocation.getBlock()
+                : destinationLocation.getBlock();
+
+        this.decisionService.makeDecisionWithContext(
+                RedstoneClockMiddleware.CheckContext.of(clockBlock, true, RedstoneClockMiddleware.EventType.HOPPER));
+    }
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/api/RedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/api/RedstoneClockMiddleware.java
@@ -36,6 +36,7 @@ public abstract class RedstoneClockMiddleware {
         SCULK_SENSOR,
         COMPARATOR,
         OBSERVER,
+        HOPPER,
     }
 
     public record CheckContext(Location location, Block block, @Nullable Boolean state, EventType eventType) {

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/SkipEventTypeRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/SkipEventTypeRedstoneClockMiddleware.java
@@ -31,6 +31,9 @@ public final class SkipEventTypeRedstoneClockMiddleware extends RedstoneClockMid
         if (context.eventType() == EventType.COMPARATOR &&
                 this.antiRedstoneClockRemastered.getConfig().getBoolean("check.comparator"))
             return checkNext(context);
+        if (context.eventType() == EventType.HOPPER &&
+                this.antiRedstoneClockRemastered.getConfig().getBoolean("check.hopper"))
+            return checkNext(context);
         return ResultState.SKIP;
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DynamicTrackingService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DynamicTrackingService.java
@@ -41,7 +41,10 @@ public final class DynamicTrackingService implements RedstoneTrackingService {
         if (clock != null) {
             if (expireOrDestroyIfNeeded(clock)) return true;
 
-            if (eventType == RedstoneClockMiddleware.EventType.REDSTONE_AND_REPEATER) {
+            // The hopper listener only reports completed back and forth cycles, so every
+            // report counts as a trigger just like a redstone signal does.
+            if (eventType == RedstoneClockMiddleware.EventType.REDSTONE_AND_REPEATER
+                    || eventType == RedstoneClockMiddleware.EventType.HOPPER) {
                 clock.incrementTriggerCount();
                 clock.setCurrentLocation(location);
             } else {

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/HopperClockTracker.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/HopperClockTracker.java
@@ -1,0 +1,132 @@
+package net.onelitefeather.antiredstoneclockremastered.service.tracking;
+
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Detects hopper clocks by watching the direction of item movements between two hoppers.
+ *
+ * <p>A hopper clock is a pair of hoppers pointing at each other, so a single item travels
+ * from hopper A to hopper B and back again. Item sorters and hopper chains only ever move
+ * items in one direction, which is why only a <em>change</em> of direction within the same
+ * hopper pair is reported as a clock cycle.</p>
+ *
+ * @author OneLiteFeather
+ * @version 1.0.0
+ * @since 2.9.0
+ */
+public final class HopperClockTracker {
+
+    /**
+     * Amount of registered movements after which expired pairs are dropped from memory.
+     */
+    private static final int PURGE_INTERVAL = 512;
+
+    private final Map<HopperPair, Movement> movements = new ConcurrentHashMap<>();
+    private final AtomicInteger movementsSincePurge = new AtomicInteger();
+
+    /**
+     * Registers an item movement between two hoppers.
+     *
+     * @param source          the hopper the item was taken from
+     * @param destination     the hopper the item was moved into
+     * @param nowSeconds      the current time in seconds
+     * @param timeoutSeconds  how long a movement stays relevant for the opposite direction
+     * @return {@code true} when this movement completed a back and forth cycle
+     */
+    public boolean registerMovement(@NotNull BlockKey source, @NotNull BlockKey destination,
+                                    long nowSeconds, long timeoutSeconds) {
+        if (source.equals(destination)) return false;
+
+        if (this.movementsSincePurge.incrementAndGet() >= PURGE_INTERVAL) {
+            this.movementsSincePurge.set(0);
+            purgeExpired(nowSeconds, timeoutSeconds);
+        }
+
+        var pair = HopperPair.of(source, destination);
+        var forward = pair.first().equals(source);
+        var previous = this.movements.put(pair, new Movement(forward, nowSeconds));
+        if (previous == null) return false;
+        if (isExpired(previous, nowSeconds, timeoutSeconds)) return false;
+        return previous.forward() != forward;
+    }
+
+    /**
+     * Forgets the given hopper pair, e.g. after the clock has been handled.
+     *
+     * @param first  one hopper of the pair
+     * @param second the other hopper of the pair
+     */
+    public void forget(@NotNull BlockKey first, @NotNull BlockKey second) {
+        this.movements.remove(HopperPair.of(first, second));
+    }
+
+    /**
+     * @return the amount of currently tracked hopper pairs
+     */
+    public int trackedPairs() {
+        return this.movements.size();
+    }
+
+    private void purgeExpired(long nowSeconds, long timeoutSeconds) {
+        this.movements.values().removeIf(movement -> isExpired(movement, nowSeconds, timeoutSeconds));
+    }
+
+    private boolean isExpired(@NotNull Movement movement, long nowSeconds, long timeoutSeconds) {
+        return nowSeconds - movement.timestamp() > timeoutSeconds;
+    }
+
+    /**
+     * Creates a key for the block at the given location.
+     *
+     * @param location the location of the hopper
+     * @return the key or {@code null} when the location has no world
+     */
+    public static @Nullable BlockKey keyOf(@NotNull Location location) {
+        var world = location.getWorld();
+        if (world == null) return null;
+        return new BlockKey(world.getUID(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
+    }
+
+    /**
+     * Identifies a single block without keeping a reference to the world or chunk.
+     */
+    public record BlockKey(@NotNull UUID world, int x, int y, int z) implements Comparable<BlockKey> {
+
+        private static final Comparator<BlockKey> ORDER = Comparator.comparing(BlockKey::world)
+                .thenComparingInt(BlockKey::x)
+                .thenComparingInt(BlockKey::y)
+                .thenComparingInt(BlockKey::z);
+
+        @Override
+        public int compareTo(@NotNull BlockKey other) {
+            return ORDER.compare(this, other);
+        }
+    }
+
+    /**
+     * A pair of hoppers in a stable order, so both movement directions share one key.
+     */
+    public record HopperPair(@NotNull BlockKey first, @NotNull BlockKey second) {
+
+        public static @NotNull HopperPair of(@NotNull BlockKey one, @NotNull BlockKey other) {
+            return one.compareTo(other) <= 0 ? new HopperPair(one, other) : new HopperPair(other, one);
+        }
+    }
+
+    /**
+     * The last movement seen for a hopper pair.
+     *
+     * @param forward   whether the item moved from {@link HopperPair#first()} to {@link HopperPair#second()}
+     * @param timestamp when the movement happened, in seconds
+     */
+    private record Movement(boolean forward, long timestamp) {
+    }
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/StaticTrackingService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/StaticTrackingService.java
@@ -38,7 +38,10 @@ public final class StaticTrackingService implements RedstoneTrackingService {
         if (clock != null) {
             if (expireOrDestroyIfNeeded(clock)) return true;
 
-            if (eventType == RedstoneClockMiddleware.EventType.REDSTONE_AND_REPEATER) {
+            // The hopper listener only reports completed back and forth cycles, so every
+            // report counts as a trigger just like a redstone signal does.
+            if (eventType == RedstoneClockMiddleware.EventType.REDSTONE_AND_REPEATER
+                    || eventType == RedstoneClockMiddleware.EventType.HOPPER) {
                 clock.incrementTriggerCount();
             } else {
                 if (clock.isActive()) {

--- a/src/main/resources/antiredstoneclockremasterd.properties
+++ b/src/main/resources/antiredstoneclockremasterd.properties
@@ -11,6 +11,7 @@ antiredstoneclockremastered.command.feature.check.toggle.piston.description=<gra
 antiredstoneclockremastered.command.feature.check.toggle.comparator.description=<gray>Turn the detection function of comparators on or off
 antiredstoneclockremastered.command.feature.check.toggle.sculk.description=<gray>Turn the detection function of sculks on or off
 antiredstoneclockremastered.command.feature.check.toggle.redstone_and_repeater.description=<gray>Turn the detection function of redstone and repeaters on or off
+antiredstoneclockremastered.command.feature.check.toggle.hopper.description=<gray>Turn the detection function of hopper clocks on or off
 antiredstoneclockremastered.command.feature.check.world.add=<arg:0> <green>The world '<arg:1>' has been added to the ignored worlds list
 antiredstoneclockremastered.command.feature.check.world.remove=<arg:0> <red>The world '<arg:1>' has been removed from the ignored worlds list
 antiredstoneclockremastered.command.feature.check.world.add.description=<gray>This command adds a world to the ignored worlds list

--- a/src/main/resources/antiredstoneclockremasterd_de_DE.properties
+++ b/src/main/resources/antiredstoneclockremasterd_de_DE.properties
@@ -11,6 +11,7 @@ antiredstoneclockremastered.command.feature.check.toggle.piston.description=<gra
 antiredstoneclockremastered.command.feature.check.toggle.comparator.description=<gray>Schaltet die Erkennungsfunktion von Vergleichern ein oder aus
 antiredstoneclockremastered.command.feature.check.toggle.sculk.description=<gray>Schalte die Erkennungsfunktion der Sculk-Sensoren ein oder aus
 antiredstoneclockremastered.command.feature.check.toggle.redstone_and_repeater.description=<gray>Schaltet die Erkennungsfunktion von Redstone und Repeater ein oder aus
+antiredstoneclockremastered.command.feature.check.toggle.hopper.description=<gray>Schaltet die Erkennungsfunktion von Trichter-Uhren ein oder aus
 antiredstoneclockremastered.command.feature.check.world.add=<arg:0> <green>Die Welt '<arg:1>' wurde zur Liste der ignorierten Welten hinzugefügt
 antiredstoneclockremastered.command.feature.check.world.remove=<arg:0> <red>Die Welt '<arg:1>' wurde von der Liste ignorierter Welten entfernt
 antiredstoneclockremastered.command.feature.check.world.add.description=<gray>Dieser Befehl fügt eine Welt zur Liste ignorierter Welten hinzu

--- a/src/main/resources/antiredstoneclockremasterd_en_US.properties
+++ b/src/main/resources/antiredstoneclockremasterd_en_US.properties
@@ -11,6 +11,7 @@ antiredstoneclockremastered.command.feature.check.toggle.piston.description=<gra
 antiredstoneclockremastered.command.feature.check.toggle.comparator.description=<gray>Turn the detection function of comparators on or off
 antiredstoneclockremastered.command.feature.check.toggle.sculk.description=<gray>Turn the detection function of sculks on or off
 antiredstoneclockremastered.command.feature.check.toggle.redstone_and_repeater.description=<gray>Turn the detection function of redstone and repeaters on or off
+antiredstoneclockremastered.command.feature.check.toggle.hopper.description=<gray>Turn the detection function of hopper clocks on or off
 antiredstoneclockremastered.command.feature.check.world.add=<arg:0> <green>The world '<arg:1>' has been added to the ignored worlds list
 antiredstoneclockremastered.command.feature.check.world.remove=<arg:0> <red>The world '<arg:1>' has been removed from the ignored worlds list
 antiredstoneclockremastered.command.feature.check.world.add.description=<gray>This command adds a world to the ignored worlds list

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,8 @@ check:
   piston: true
   comparator: true
   sculk: true
+  # A hopper clock is a pair of hoppers pointing at each other, moving an item back and forth
+  hopper: true
   ignoredWorlds:
     - world
   ignoredRegions: []

--- a/src/test/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/HopperClockTrackerTest.java
+++ b/src/test/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/HopperClockTrackerTest.java
@@ -1,0 +1,148 @@
+package net.onelitefeather.antiredstoneclockremastered.service.tracking;
+
+import net.onelitefeather.antiredstoneclockremastered.service.tracking.HopperClockTracker.BlockKey;
+import net.onelitefeather.antiredstoneclockremastered.service.tracking.HopperClockTracker.HopperPair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the hopper clock detection.
+ */
+class HopperClockTrackerTest {
+
+    private static final UUID WORLD = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID OTHER_WORLD = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final long TIMEOUT = 300L;
+
+    private static final BlockKey HOPPER_A = new BlockKey(WORLD, 10, 64, 10);
+    private static final BlockKey HOPPER_B = new BlockKey(WORLD, 11, 64, 10);
+    private static final BlockKey HOPPER_C = new BlockKey(WORLD, 12, 64, 10);
+
+    private HopperClockTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        this.tracker = new HopperClockTracker();
+    }
+
+    @Test
+    @DisplayName("A single movement is not a clock")
+    void singleMovementIsNoClock() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Movements in the same direction are not a clock")
+    void sameDirectionIsNoClock() {
+        for (int second = 0; second < 50; second++) {
+            assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, second, TIMEOUT))
+                    .as("movement %s", second)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("A hopper chain of a sorting system is not a clock")
+    void hopperChainIsNoClock() {
+        for (int second = 0; second < 20; second++) {
+            assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, second, TIMEOUT)).isFalse();
+            assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_C, second, TIMEOUT)).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("A movement back to the source is a clock")
+    void movementBackIsAClock() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_A, 1, TIMEOUT)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Every direction change of a running clock is reported")
+    void everyCycleIsReported() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        for (int second = 1; second < 10; second++) {
+            var from = second % 2 == 0 ? HOPPER_A : HOPPER_B;
+            var to = second % 2 == 0 ? HOPPER_B : HOPPER_A;
+            assertThat(this.tracker.registerMovement(from, to, second, TIMEOUT))
+                    .as("cycle %s", second)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("A direction change after the timeout starts over")
+    void expiredMovementIsNoClock() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_A, TIMEOUT + 1, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, TIMEOUT + 2, TIMEOUT)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Hopper pairs are tracked independently")
+    void pairsAreTrackedIndependently() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_C, 1, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(HOPPER_C, HOPPER_B, 2, TIMEOUT)).isTrue();
+        assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_A, 3, TIMEOUT)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Same block coordinates in different worlds are different hoppers")
+    void worldsAreNotMixedUp() {
+        var otherWorldA = new BlockKey(OTHER_WORLD, HOPPER_A.x(), HOPPER_A.y(), HOPPER_A.z());
+        var otherWorldB = new BlockKey(OTHER_WORLD, HOPPER_B.x(), HOPPER_B.y(), HOPPER_B.z());
+
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        assertThat(this.tracker.registerMovement(otherWorldB, otherWorldA, 1, TIMEOUT)).isFalse();
+        assertThat(this.tracker.trackedPairs()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("A movement into itself is ignored")
+    void selfMovementIsIgnored() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_A, 0, TIMEOUT)).isFalse();
+        assertThat(this.tracker.trackedPairs()).isZero();
+    }
+
+    @Test
+    @DisplayName("A forgotten pair starts over")
+    void forgottenPairStartsOver() {
+        assertThat(this.tracker.registerMovement(HOPPER_A, HOPPER_B, 0, TIMEOUT)).isFalse();
+        this.tracker.forget(HOPPER_B, HOPPER_A);
+        assertThat(this.tracker.trackedPairs()).isZero();
+        assertThat(this.tracker.registerMovement(HOPPER_B, HOPPER_A, 1, TIMEOUT)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Expired pairs are removed from memory")
+    void expiredPairsArePurged() {
+        for (int hopper = 0; hopper < 600; hopper++) {
+            var source = new BlockKey(WORLD, hopper, 64, 0);
+            var destination = new BlockKey(WORLD, hopper, 64, 1);
+            this.tracker.registerMovement(source, destination, 0, TIMEOUT);
+        }
+        assertThat(this.tracker.trackedPairs()).isEqualTo(600);
+
+        this.tracker.registerMovement(HOPPER_A, HOPPER_B, TIMEOUT * 10, TIMEOUT);
+        // The purge runs every 512 movements, so it has not been triggered again yet.
+        assertThat(this.tracker.trackedPairs()).isEqualTo(601);
+
+        for (int hopper = 0; hopper < 512; hopper++) {
+            this.tracker.registerMovement(HOPPER_A, HOPPER_B, TIMEOUT * 10, TIMEOUT);
+        }
+        assertThat(this.tracker.trackedPairs()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Both movement directions share the same pair")
+    void pairOrderIsStable() {
+        assertThat(HopperPair.of(HOPPER_A, HOPPER_B)).isEqualTo(HopperPair.of(HOPPER_B, HOPPER_A));
+        assertThat(HopperPair.of(HOPPER_B, HOPPER_A).first()).isEqualTo(HOPPER_A);
+    }
+}


### PR DESCRIPTION
Closes #229

## What

Hopper clocks — two hoppers pointing at each other, moving the same item back and forth — were not detected by any existing check. They keep the server busy without a single piece of redstone involved.

## How

A new `HopperListener` watches `InventoryMoveItemEvent` and hands the movement to `HopperClockTracker`, which remembers the last direction per hopper pair. Only a **change of direction** within the same pair is reported as a clock cycle, exactly as described in the issue:

- `A -> B` followed by `B -> A` is a cycle and gets reported
- `A -> B -> C` (item sorters, hopper chains) never reverses, so nothing is reported

From there the existing pipeline takes over unchanged: `SkipEventTypeRedstoneClockMiddleware` honours the config toggle, the tracking services count cycles against `clock.maxCount` / `clock.endDelay`, and `BukkitDecisionService` notifies and/or removes the block. Because the listener already reports only completed cycles, `EventType.HOPPER` is counted like `REDSTONE_AND_REPEATER` (one report = one trigger).

The reported block is always the same hopper of the pair (stable ordering by world and coordinates), otherwise every cycle would be tracked as a separate clock.

## Config, command and help menu

```yaml
check:
  # A hopper clock is a pair of hoppers pointing at each other, moving an item back and forth
  hopper: true
```

`/arcm feature check hopper` toggles it at runtime (permission `antiredstoneclockremastered.command.feature.check.hopper`, registered in the plugin description and in the admin bundle). The entry appears in `/arcm help` automatically through its `@CommandDescription`, whose translation key was added to the Crowdin source file plus the English and German bundles.

## Performance

`InventoryMoveItemEvent` fires for every item movement on the server, so the listener bails out on the config flag first and then on a plain `Material.HOPPER` block check on both sides — no `BlockState` snapshots are created. Tracked pairs are dropped from memory once they are older than `clock.endDelay`.

## Notes for review

- The listener runs at `HIGHEST` with `ignoreCancelled = true`: movements cancelled by another plugin never happened and must not count, but the decision service still needs to be able to modify the block.
- When `clock.autoBreak` is enabled the hopper is removed like any other clock block, so its contents are lost. That is the same behaviour the plugin already has for other blocks and it is opt-out via `clock.autoBreak` / `clock.drop`.
- `HopperClockTrackerTest` covers the sorting-system case, running clocks, timeout handling, world separation and memory purging.

## Tests

`./gradlew build` — green, 18 tests pass.