### PR TITLE
feat: add debug logging into an own log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,33 @@ For Minecraft version 1.20, it would be 1.20.6 and so on
 > [!CAUTION]
 > The "world" world is ignored by default
 
+## Debug logs
+When something does not work as expected, switch on debug logging with
+
+```
+/arcm feature debug
+```
+
+or in the `config.yml`:
+
+```yaml
+debug:
+  enabled: true
+  # How many rotated log files are kept next to latest.log
+  keepFiles: 5
+```
+
+Both take effect right away, no restart needed.
+
+Debug messages are written to `plugins/AntiRedstoneClock-Remastered/debug-logs/latest.log` and never
+show up in the server log, because they are far too noisy for it. Warnings and errors go to the server
+log as usual and are written to this file as well, so it contains the whole picture when you attach it
+to a bug report.
+
+The file is handled by the same Log4j2 the server itself logs with, so it behaves just like
+`logs/latest.log`: it rolls over on every server start and once it grows past 10 MB, and older files
+are compressed to `.log.gz`. `keepFiles` decides how many of them are kept.
+
 ## Contribution
 You want to help us? Sure go for it, we would love to see your contribution! You can look for open issues or if you have a nice idea, please open an issue or ask us on discord if you can add your feature with a PR. Communication is key.
 
@@ -59,6 +86,8 @@ antiredstoneclockremastered.notify.admin
   - Reloads the config
 - /arcm help
   - Shows all commands and descriptions
+- /arcm feature debug
+  - Turns debug logging on or off
 - /arcm display
   - Shows current cached redstone clocks
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,8 +86,11 @@ dependencies {
     implementation(project(":PlotSquaredv6Support"))
     implementation(project(":PlotSquaredv7Support"))
 
+    compileOnly(libs.log4j.core)
+
     // Testing dependencies
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.log4j.core)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.junit.jupiter)
     testImplementation(libs.mockbukkit)
@@ -208,6 +211,7 @@ paper {
         register("antiredstoneclockremastered.command.feature.clock.drop")
         register("antiredstoneclockremastered.command.feature.clock.enddelay")
         register("antiredstoneclockremastered.command.feature.clock.maxCount")
+        register("antiredstoneclockremastered.command.feature.debug")
         register("antiredstoneclockremastered.bundle.admin") {
             children = listOf(
                 "antiredstoneclockremastered.notify.admin",
@@ -229,6 +233,7 @@ paper {
                 "antiredstoneclockremastered.command.feature.clock.drop",
                 "antiredstoneclockremastered.command.feature.clock.enddelay",
                 "antiredstoneclockremastered.command.feature.clock.maxCount",
+                "antiredstoneclockremastered.command.feature.debug",
                 "antiredstoneclockremastered.command.display"
             )
             default = BukkitPluginDescription.Permission.Default.OP

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ dependencyResolutionManagement {
             version("cyclonedx", "3.3.0")
 
             version("paper", "26.1.2.build.+")
+            version("log4j", "2.25.2")
             version("bstats", "3.2.1")
             version("customblockdata", "2.2.5")
 
@@ -68,6 +69,7 @@ dependencyResolutionManagement {
             library("psv7.bukkit", "com.intellectualsites.plotsquared","plotsquared-bukkit").withoutVersion()
 
             library("paper", "io.papermc.paper", "paper-api").versionRef("paper")
+            library("log4j.core", "org.apache.logging.log4j", "log4j-core").versionRef("log4j")
             library("adventure.text.discord", "dev.vankka", "mcdiscordreserializer").versionRef("adventure-text-discord-serializer")
             library("jda-webhook", "club.minnced", "discord-webhooks").versionRef("jda-webhook")
             library("bstats", "org.bstats", "bstats-bukkit").versionRef("bstats")

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/AntiRedstoneClockRemastered.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/AntiRedstoneClockRemastered.java
@@ -16,16 +16,26 @@ import net.onelitefeather.antiredstoneclockremastered.injection.PlatformModule;
 import net.onelitefeather.antiredstoneclockremastered.injection.ServiceModule;
 import net.onelitefeather.antiredstoneclockremastered.injection.TranslationModule;
 import net.onelitefeather.antiredstoneclockremastered.service.UpdateService;
+import net.onelitefeather.antiredstoneclockremastered.service.logging.DebugLogging;
 import net.onelitefeather.antiredstoneclockremastered.service.tracking.ConfigMode;
 import net.onelitefeather.antiredstoneclockremastered.utils.CheckTPS;
-import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 
 public final class AntiRedstoneClockRemastered extends JavaPlugin {
-    
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AntiRedstoneClockRemastered.class);
+
+    /**
+     * Directory inside the plugin folder the debug log files are written to.
+     */
+    private static final String DEBUG_LOG_DIRECTORY = "debug-logs";
+
     // Injector for dependency injection
     private Injector injector;
 
@@ -36,6 +46,8 @@ public final class AntiRedstoneClockRemastered extends JavaPlugin {
         saveDefaultConfig();
         reloadConfig();
         saveConfig();
+        setupDebugLogging();
+        LOGGER.debug("Creating injector with modules");
         injector = Guice.createInjector(Stage.PRODUCTION, Arrays.asList(
                 new PlatformModule(this),
                 new TranslationModule(),
@@ -45,10 +57,45 @@ public final class AntiRedstoneClockRemastered extends JavaPlugin {
                 new ListenerModule()
                 )
         );
+        LOGGER.debug("Injector created");
+    }
+
+    /**
+     * Reloads the configuration and applies everything that depends on it.
+     */
+    public void reloadPluginConfig() {
+        reloadConfig();
+        setupDebugLogging();
+        LOGGER.debug("Configuration reloaded");
+    }
+
+    /**
+     * Opens or closes the debug log depending on the {@code debug.enabled} config option.
+     *
+     * <p>Debug messages are kept out of the server log on purpose, they can be very noisy.</p>
+     */
+    private void setupDebugLogging() {
+        var enabled = getConfig().getBoolean("debug.enabled");
+        if (enabled == DebugLogging.isEnabled()) return;
+
+        if (!enabled) {
+            LOGGER.debug("Debug logging has been disabled");
+            DebugLogging.disable();
+            return;
+        }
+
+        Path directory = getDataFolder().toPath().resolve(DEBUG_LOG_DIRECTORY);
+        if (DebugLogging.enable(directory, getConfig().getInt("debug.keepFiles", 5))) {
+            LOGGER.info("Debug logging is enabled, messages are written to {}",
+                    directory.resolve(DebugLogging.LATEST_LOG_NAME));
+            return;
+        }
+        LOGGER.warn("This server does not run on Log4j2, debug logging is not available");
     }
 
     @Override
     public void onEnable() {
+        LOGGER.debug("Enabling plugin version {}", getPluginMeta().getVersion());
         CustomBlockData.registerListener(this);
         injector.getInstance(TranslationModule.class);
         var mode = ConfigMode.getEnum(getConfig(), "check.mode", ConfigMode.STATIC);
@@ -62,10 +109,14 @@ public final class AntiRedstoneClockRemastered extends JavaPlugin {
         injector.getInstance(CommandFrameworkModule.class).enable();
         injector.getInstance(MetricsModule.class).registerCharts();
         this.injector.getInstance(ListenerModule.class).registerEvents(injector, this);
+        LOGGER.debug("Plugin enabled in {} mode", mode);
     }
+
     @Override
     public void onDisable() {
+        LOGGER.debug("Disabling plugin");
         injector.getInstance(UpdateService.class).shutdown();
+        DebugLogging.disable();
     }
 
     private void donationInformation() {

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/FeatureCommand.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/FeatureCommand.java
@@ -12,6 +12,8 @@ import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
 import org.incendo.cloud.annotations.Permission;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.List;
 
 /**
@@ -23,6 +25,8 @@ import java.util.List;
  */
 @Command("arcm feature")
 public final class FeatureCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FeatureCommand.class);
 
     private final AntiRedstoneClockRemastered plugin;
     private final DecisionService decisionService;
@@ -94,6 +98,7 @@ public final class FeatureCommand {
     }
 
     private void sendMessageToggleMessage(CommandSender sender, boolean value) {
+        LOGGER.debug("{} toggled a feature to {}", sender.getName(), value);
         if (value) {
             sender.sendMessage(Component.translatable("antiredstoneclockremastered.command.feature.check.toggle.enabled").arguments(AntiRedstoneClockRemastered.PREFIX));
         } else {
@@ -209,7 +214,18 @@ public final class FeatureCommand {
         sendMessageSetMessage(sender, plugin.getConfig().getInt("clock.maxCount"));
     }
 
+    @Command("debug")
+    @CommandDescription("antiredstoneclockremastered.command.feature.debug.toggle.description")
+    @Permission("antiredstoneclockremastered.command.feature.debug")
+    public void toggleDebug(CommandSender sender) {
+        plugin.getConfig().set("debug.enabled", !plugin.getConfig().getBoolean("debug.enabled"));
+        plugin.saveConfig();
+        decisionService.reload();
+        sendMessageToggleMessage(sender, plugin.getConfig().getBoolean("debug.enabled"));
+    }
+
     private void sendMessageSetMessage(CommandSender sender, Integer value) {
+        LOGGER.debug("{} changed a value to {}", sender.getName(), value);
         sender.sendMessage(Component.translatable("antiredstoneclockremastered.command.feature.clock.set").arguments(AntiRedstoneClockRemastered.PREFIX, TranslationArgument.numeric(value)));
     }
 

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/ReloadCommand.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/commands/ReloadCommand.java
@@ -8,6 +8,8 @@ import org.bukkit.command.CommandSender;
 import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
 import org.incendo.cloud.annotations.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Command for reloading the plugin configuration.
@@ -17,6 +19,8 @@ import org.incendo.cloud.annotations.Permission;
  * @version 1.0.0
  */
 public final class ReloadCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReloadCommand.class);
 
     private final DecisionService decisionService;
 
@@ -29,6 +33,7 @@ public final class ReloadCommand {
     @CommandDescription("antiredstoneclockremastered.command.reload.description")
     @Permission("antiredstoneclockremastered.command.reload")
     public void reloadConfig(CommandSender commandSender) {
+        LOGGER.debug("{} reloads the configuration", commandSender.getName());
         this.decisionService.reload();
         commandSender.sendMessage(Component.translatable("antiredstoneclockremastered.command.reload.success").arguments(AntiRedstoneClockRemastered.PREFIX));
     }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ExternalSupportModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ExternalSupportModule.java
@@ -13,9 +13,9 @@ import net.onelitefeather.antiredstoneclockremastered.support.NoOpWorldGuardSupp
 import net.onelitefeather.antiredstoneclockremastered.worldguard.v6.WorldGuardLegacySupport;
 import net.onelitefeather.antiredstoneclockremastered.worldguard.v7.WorldGuardModernSupport;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Guice module for external plugin support dependencies.
@@ -39,7 +39,7 @@ public final class ExternalSupportModule extends AbstractModule {
     public WorldGuardSupport provideWorldGuardSupport(AntiRedstoneClockRemastered plugin) {
         Plugin wgPlugin = plugin.getServer().getPluginManager().getPlugin("WorldGuard");
         if (wgPlugin == null) {
-            LOGGER.warn("WorldGuard hasn't been found!");
+            LOGGER.debug("WorldGuard has not been found, region checks are skipped");
             return new NoOpWorldGuardSupport(plugin);
         }
         
@@ -68,7 +68,7 @@ public final class ExternalSupportModule extends AbstractModule {
     public PlotsquaredSupport providePlotsquaredSupport(AntiRedstoneClockRemastered plugin) {
         Plugin psPlugin = plugin.getServer().getPluginManager().getPlugin("PlotSquared");
         if (psPlugin == null) {
-            LOGGER.warn("PlotSquared hasn't been found!");
+            LOGGER.debug("PlotSquared has not been found, plot checks are skipped");
             return new NoOpPlotSquaredSupport();
         }
         

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ListenerModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ListenerModule.java
@@ -6,6 +6,8 @@ import net.onelitefeather.antiredstoneclockremastered.listener.*;
 import net.onelitefeather.antiredstoneclockremastered.service.api.DecisionService;
 import org.bukkit.Material;
 import org.bukkit.plugin.Plugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Guice module for listener dependencies.
@@ -15,6 +17,8 @@ import org.bukkit.plugin.Plugin;
  * @version 1.0.0
  */
 public final class ListenerModule extends AbstractModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListenerModule.class);
     
     @Override
     protected void configure() {
@@ -40,6 +44,7 @@ public final class ListenerModule extends AbstractModule {
     }
 
     public void registerEvents(Injector injector, Plugin plugin) {
+        LOGGER.debug("Registering listeners");
         // Register DI-enabled listeners
         plugin.getServer().getPluginManager().registerEvents(injector.getInstance(PlayerListener.class), plugin);
         plugin.getServer().getPluginManager().registerEvents(injector.getInstance(ObserverListener.class), plugin);

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ServiceModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/ServiceModule.java
@@ -46,6 +46,8 @@ public final class ServiceModule extends AbstractModule {
         var consoleNotification = new ConsoleNotificationService(antiRedstoneClockRemastered, adminNotifications);
         var signNotifications = new SignNotificationService(antiRedstoneClockRemastered, consoleNotification, regionService);
         var discordNotification = new DiscordNotificationService(antiRedstoneClockRemastered, signNotifications);
+        LOGGER.debug("Built notification chain: discord -> sign -> console -> admins, enabled targets are {}",
+                antiRedstoneClockRemastered.getConfig().getStringList("notification.enabled"));
         return discordNotification;
     }
 
@@ -71,6 +73,7 @@ public final class ServiceModule extends AbstractModule {
     @Provides
     @Singleton
     public RedstoneClockMiddleware provideRedstoneClockMiddleware(Injector injector) {
+        LOGGER.debug("Building middleware chain: tps -> event type -> world -> worldguard -> plotsquared -> tracking");
         return RedstoneClockMiddleware.link(
                 injector.getInstance(TPSRedstoneClockMiddleware.class),
                 injector.getInstance(SkipEventTypeRedstoneClockMiddleware.class),

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModule.java
@@ -11,9 +11,9 @@ import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastere
 import net.onelitefeather.antiredstoneclockremastered.service.api.TranslationService;
 import net.onelitefeather.antiredstoneclockremastered.service.translation.LegacyTranslationService;
 import net.onelitefeather.antiredstoneclockremastered.service.translation.ModernTranslationService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -67,12 +67,13 @@ public final class TranslationModule extends AbstractModule {
             try {
                 Files.createDirectories(langFolder);
             } catch (IOException e) {
-                LOGGER.error("An error occurred while creating lang folder");
+                LOGGER.error("Could not create the lang folder {}, translations stay on their defaults", langFolder, e);
                 return;
             }
         }
         var languages = new HashSet<>(plugin.getConfig().getStringList("translations"));
         languages.add("en-US");
+        LOGGER.debug("Loading translations for {}", languages);
         languages.stream()
                 .map(Locale::forLanguageTag)
                 .forEach(locale -> loadAndRegisterTranslation(locale, langFolder, translationService));

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/listener/HopperListener.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/listener/HopperListener.java
@@ -10,6 +10,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Listener for handling hopper clocks.
@@ -23,6 +25,8 @@ import org.bukkit.event.inventory.InventoryMoveItemEvent;
  * @since 2.9.0
  */
 public final class HopperListener implements Listener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HopperListener.class);
 
     private final AntiRedstoneClockRemastered plugin;
     private final DecisionService decisionService;
@@ -55,6 +59,8 @@ public final class HopperListener implements Listener {
         if (!this.tracker.registerMovement(sourceKey, destinationKey, System.currentTimeMillis() / 1000, timeout)) {
             return;
         }
+
+        LOGGER.debug("Hopper at {} moved an item back to {}", sourceLocation, destinationLocation);
 
         // Always report the same hopper of the pair, otherwise every cycle would be tracked as its own clock.
         var pair = HopperClockTracker.HopperPair.of(sourceKey, destinationKey);

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/UpdateService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/UpdateService.java
@@ -11,9 +11,9 @@ import net.onelitefeather.antiredstoneclockremastered.service.api.SchedulerServi
 import net.onelitefeather.antiredstoneclockremastered.utils.Constants;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.http.HttpClient;

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/PlotSquaredRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/PlotSquaredRedstoneClockMiddleware.java
@@ -3,9 +3,13 @@ package net.onelitefeather.antiredstoneclockremastered.service.chain;
 import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.api.PlotsquaredSupport;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class PlotSquaredRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlotSquaredRedstoneClockMiddleware.class);
 
     private final PlotsquaredSupport plotsquaredSupport;
 
@@ -16,7 +20,11 @@ public final class PlotSquaredRedstoneClockMiddleware extends RedstoneClockMiddl
 
     @Override
     public @NotNull ResultState check(@NotNull CheckContext context) {
-        if (this.plotsquaredSupport.isAllowedPlot(context.location())) return ResultState.SKIP;
+        if (this.plotsquaredSupport.isAllowedPlot(context.location())) {
+            LOGGER.debug("Skipping {} check, a PlotSquared plot allows redstone clocks at {}",
+                    context.eventType(), context.location());
+            return ResultState.SKIP;
+        }
         return checkNext(context);
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/SkipEventTypeRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/SkipEventTypeRedstoneClockMiddleware.java
@@ -3,9 +3,13 @@ package net.onelitefeather.antiredstoneclockremastered.service.chain;
 import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class SkipEventTypeRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipEventTypeRedstoneClockMiddleware.class);
 
     private final AntiRedstoneClockRemastered antiRedstoneClockRemastered;
 
@@ -34,6 +38,7 @@ public final class SkipEventTypeRedstoneClockMiddleware extends RedstoneClockMid
         if (context.eventType() == EventType.HOPPER &&
                 this.antiRedstoneClockRemastered.getConfig().getBoolean("check.hopper"))
             return checkNext(context);
+        LOGGER.debug("Skipping {} check, the detection for this block type is disabled", context.eventType());
         return ResultState.SKIP;
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/TPSRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/TPSRedstoneClockMiddleware.java
@@ -3,9 +3,13 @@ package net.onelitefeather.antiredstoneclockremastered.service.chain;
 import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
 import net.onelitefeather.antiredstoneclockremastered.utils.CheckTPS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class TPSRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TPSRedstoneClockMiddleware.class);
 
     private final CheckTPS checkTPS;
 
@@ -16,7 +20,11 @@ public final class TPSRedstoneClockMiddleware extends RedstoneClockMiddleware {
 
     @Override
     public @NotNull ResultState check(@NotNull CheckContext context) {
-        if (!this.checkTPS.isTpsOk()) return ResultState.SKIP;
+        if (!this.checkTPS.isTpsOk()) {
+            LOGGER.debug("Skipping {} check, the configured TPS range is not met (current: {})",
+                    context.eventType(), this.checkTPS.getTps());
+            return ResultState.SKIP;
+        }
         return checkNext(context);
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/TrackingRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/TrackingRedstoneClockMiddleware.java
@@ -4,9 +4,13 @@ import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneTrackingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class TrackingRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TrackingRedstoneClockMiddleware.class);
 
     private final RedstoneTrackingService trackingService;
     private final AntiRedstoneClockRemastered antiRedstoneClockRemastered;
@@ -21,6 +25,7 @@ public final class TrackingRedstoneClockMiddleware extends RedstoneClockMiddlewa
     @Override
     public @NotNull ResultState check(@NotNull CheckContext context) {
         if (this.trackingService.isRedstoneClock(context)) {
+            LOGGER.debug("Detected a {} redstone clock at {}", context.eventType(), context.location());
             var autoBreak = this.antiRedstoneClockRemastered.getConfig().getBoolean("clock.autoBreak", true);
             if (!autoBreak) return ResultState.ONLY_NOTIFY;
             var autoDrop = this.antiRedstoneClockRemastered.getConfig().getBoolean("clock.drop", false);

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/WorldGuardRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/WorldGuardRedstoneClockMiddleware.java
@@ -3,9 +3,13 @@ package net.onelitefeather.antiredstoneclockremastered.service.chain;
 import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.api.WorldGuardSupport;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class WorldGuardRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldGuardRedstoneClockMiddleware.class);
 
     private final WorldGuardSupport worldGuardSupport;
 
@@ -16,7 +20,11 @@ public final class WorldGuardRedstoneClockMiddleware extends RedstoneClockMiddle
 
     @Override
     public @NotNull ResultState check(@NotNull CheckContext context) {
-        if (this.worldGuardSupport.isRegionAllowed(context.location())) return ResultState.SKIP;
+        if (this.worldGuardSupport.isRegionAllowed(context.location())) {
+            LOGGER.debug("Skipping {} check, a WorldGuard region allows redstone clocks at {}",
+                    context.eventType(), context.location());
+            return ResultState.SKIP;
+        }
         return checkNext(context);
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/WorldRedstoneClockMiddleware.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/chain/WorldRedstoneClockMiddleware.java
@@ -3,9 +3,13 @@ package net.onelitefeather.antiredstoneclockremastered.service.chain;
 import jakarta.inject.Inject;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 public final class WorldRedstoneClockMiddleware extends RedstoneClockMiddleware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldRedstoneClockMiddleware.class);
 
     private final AntiRedstoneClockRemastered antiRedstoneClockRemastered;
 
@@ -17,7 +21,11 @@ public final class WorldRedstoneClockMiddleware extends RedstoneClockMiddleware 
     @Override
     public @NotNull ResultState check(@NotNull CheckContext context) {
         var ignoredWorlds = this.antiRedstoneClockRemastered.getConfig().getStringList("check.ignoredWorlds");
-        if (ignoredWorlds.contains(context.location().getWorld().getName())) return ResultState.SKIP;
+        var world = context.location().getWorld().getName();
+        if (ignoredWorlds.contains(world)) {
+            LOGGER.debug("Skipping {} check, world {} is ignored", context.eventType(), world);
+            return ResultState.SKIP;
+        }
         return checkNext(context);
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/decision/BukkitDecisionService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/decision/BukkitDecisionService.java
@@ -6,10 +6,13 @@ import net.onelitefeather.antiredstoneclockremastered.service.api.DecisionServic
 import net.onelitefeather.antiredstoneclockremastered.service.api.NotificationService;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RegionService;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -21,6 +24,8 @@ import org.jetbrains.annotations.NotNull;
  * @since 1.0.0
  */
 public final class BukkitDecisionService implements DecisionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BukkitDecisionService.class);
 
     private final @NotNull AntiRedstoneClockRemastered antiRedstoneClockRemastered;
     private final RegionService regionService;
@@ -46,6 +51,7 @@ public final class BukkitDecisionService implements DecisionService {
         if (resultState == RedstoneClockMiddleware.ResultState.SKIP) {
             return;
         }
+        LOGGER.debug("Handling {} clock at {}", context.eventType(), context.location());
         this.notificationService.sendNotificationMessage(context.location());
         if (resultState == RedstoneClockMiddleware.ResultState.ONLY_NOTIFY) {
             return;
@@ -57,23 +63,25 @@ public final class BukkitDecisionService implements DecisionService {
             Block block = location.getBlock();
             var drops = block.getDrops(SILK_TOUCH_PICKAXE);
             drops.forEach(itemStack -> block.getWorld().dropItem(location, itemStack));
-            Runnable removeTask = () -> block.setType(Material.AIR, true);
-            if (this.regionService.isRegionOwner(location)) {
-                this.regionService.executeInRegion(location, removeTask);
-            }
+            removeBlock(block, location);
             return;
         }
         if (resultState == RedstoneClockMiddleware.ResultState.REMOVE_AND_WITHOUT_DROP) {
-            Block block = location.getBlock();
-            Runnable removeTask = () -> block.setType(Material.AIR, true);
-            if (this.regionService.isRegionOwner(location)) {
-                this.regionService.executeInRegion(location, removeTask);
-            }
+            removeBlock(location.getBlock(), location);
         }
+    }
+
+    private void removeBlock(@NotNull Block block, @NotNull Location location) {
+        if (!this.regionService.isRegionOwner(location)) {
+            LOGGER.warn("Could not remove the redstone clock at {}, its region is not owned by the current thread", location);
+            return;
+        }
+        LOGGER.debug("Removing {} at {}", block.getType(), location);
+        this.regionService.executeInRegion(location, () -> block.setType(Material.AIR, true));
     }
 
     @Override
     public void reload() {
-        this.antiRedstoneClockRemastered.reloadConfig();
+        this.antiRedstoneClockRemastered.reloadPluginConfig();
     }
 }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/DecisionServiceFactory.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/DecisionServiceFactory.java
@@ -6,9 +6,9 @@ import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockM
 import net.onelitefeather.antiredstoneclockremastered.service.api.DecisionService;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RegionService;
 import net.onelitefeather.antiredstoneclockremastered.service.decision.BukkitDecisionService;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Factory for creating RedstoneClockService implementations.

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/FoliaHelper.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/FoliaHelper.java
@@ -1,8 +1,12 @@
 package net.onelitefeather.antiredstoneclockremastered.service.factory;
 
 import io.papermc.paper.ServerBuildInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class FoliaHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FoliaHelper.class);
 
     /**
      * Detects if the server is running on Folia.
@@ -21,8 +25,10 @@ final class FoliaHelper {
                 Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
                 return true;
             }
+            LOGGER.debug("Minecraft version {} is not checked for Folia support", version);
             return false;
         } catch (ClassNotFoundException e) {
+            LOGGER.debug("No Folia classes found, running on a regular Paper server");
             return false;
         }
     }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/RegionServiceFactory.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/RegionServiceFactory.java
@@ -4,9 +4,9 @@ import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastere
 import net.onelitefeather.antiredstoneclockremastered.service.api.RegionService;
 import net.onelitefeather.antiredstoneclockremastered.service.region.BukkitRegionService;
 import net.onelitefeather.antiredstoneclockremastered.service.region.FoliaRegionService;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Factory for creating instances of RegionService based on the server environment.

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/SchedulerServiceFactory.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/factory/SchedulerServiceFactory.java
@@ -4,9 +4,9 @@ import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastere
 import net.onelitefeather.antiredstoneclockremastered.service.api.SchedulerService;
 import net.onelitefeather.antiredstoneclockremastered.service.scheduler.BukkitSchedulerService;
 import net.onelitefeather.antiredstoneclockremastered.service.scheduler.FoliaSchedulerService;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Factory for creating instances of SchedulerService based on the server environment.

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/logging/DebugLogging.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/logging/DebugLogging.java
@@ -1,0 +1,152 @@
+package net.onelitefeather.antiredstoneclockremastered.service.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.OnStartupTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+/**
+ * Routes the debug messages of this plugin into an own log file.
+ *
+ * <p>This uses the Log4j2 setup the server already runs on: a rolling file appender is attached to
+ * the logger of this plugin's package, and the appenders the server configured for itself are
+ * re-attached at {@link Level#INFO}. Debug messages therefore end up in
+ * {@code debug-logs/latest.log} only, while warnings and errors keep showing up in the server log
+ * and are written to the plugin log as well.</p>
+ *
+ * <p>While debug logging is off, the plugin logger simply inherits the server's log level, so
+ * {@code LOGGER.debug(...)} calls cost nothing more than a level check.</p>
+ *
+ * @author OneLiteFeather
+ * @version 1.0.0
+ * @since 2.9.0
+ */
+public final class DebugLogging {
+
+    /**
+     * Name of the log file that is always the current one.
+     */
+    public static final String LATEST_LOG_NAME = "latest.log";
+
+    /**
+     * Package every logger of this plugin lives under.
+     */
+    static final String PLUGIN_LOGGER_NAME = "net.onelitefeather.antiredstoneclockremastered";
+
+    static final String APPENDER_NAME = "AntiRedstoneClockRemasteredDebugLog";
+
+    private static final String FILE_PATTERN = "%d{yyyy-MM-dd}-%i.log.gz";
+    private static final String PATTERN = "[%d{HH:mm:ss.SSS}] [%t/%level] [%logger{1}] %msg%n%throwable";
+    private static final String MAX_FILE_SIZE = "10 MB";
+
+    private DebugLogging() {
+        // Utility class
+    }
+
+    /**
+     * Sends every debug message of this plugin to {@code latest.log} inside the given directory.
+     *
+     * @param directory the directory the log files are written to
+     * @param keepFiles how many rolled over files are kept
+     * @return {@code false} when the server does not run on Log4j2 and nothing could be set up
+     */
+    public static synchronized boolean enable(@NotNull Path directory, int keepFiles) {
+        var context = LogManager.getContext(false);
+        if (!(context instanceof LoggerContext loggerContext)) return false;
+
+        var configuration = loggerContext.getConfiguration();
+        var appender = createAppender(configuration, directory, keepFiles);
+        appender.start();
+        configuration.addAppender(appender);
+
+        // additivity is off, otherwise the debug messages would bubble up into the server log
+        var loggerConfig = new LoggerConfig(PLUGIN_LOGGER_NAME, Level.DEBUG, false);
+        loggerConfig.addAppender(appender, Level.DEBUG, null);
+        for (var serverAppender : configuration.getRootLogger().getAppenders().values()) {
+            loggerConfig.addAppender(serverAppender, Level.INFO, null);
+        }
+
+        configuration.addLogger(PLUGIN_LOGGER_NAME, loggerConfig);
+        loggerContext.updateLoggers();
+        return true;
+    }
+
+    /**
+     * Stops writing the plugin log and hands the loggers back to the server configuration.
+     */
+    public static synchronized void disable() {
+        var context = LogManager.getContext(false);
+        if (!(context instanceof LoggerContext loggerContext)) return;
+
+        var configuration = loggerContext.getConfiguration();
+        if (!isEnabled(configuration)) return;
+
+        configuration.removeLogger(PLUGIN_LOGGER_NAME);
+
+        Appender appender = configuration.getAppender(APPENDER_NAME);
+        if (configuration instanceof AbstractConfiguration abstractConfiguration) {
+            abstractConfiguration.removeAppender(APPENDER_NAME);
+        } else if (appender != null) {
+            appender.stop();
+        }
+        if (appender instanceof RollingRandomAccessFileAppender fileAppender) {
+            // Stopping the appender only drops a reference to the manager, the file stays open until
+            // the manager itself is closed - on Windows it would stay locked otherwise.
+            fileAppender.getManager().close();
+        }
+
+        loggerContext.updateLoggers();
+    }
+
+    /**
+     * @return whether the plugin log is currently being written
+     */
+    public static synchronized boolean isEnabled() {
+        var context = LogManager.getContext(false);
+        return context instanceof LoggerContext loggerContext && isEnabled(loggerContext.getConfiguration());
+    }
+
+    private static boolean isEnabled(@NotNull Configuration configuration) {
+        return configuration.getLoggers().containsKey(PLUGIN_LOGGER_NAME);
+    }
+
+    private static @NotNull RollingRandomAccessFileAppender createAppender(@NotNull Configuration configuration,
+                                                                          @NotNull Path directory, int keepFiles) {
+        var layout = PatternLayout.newBuilder()
+                .withConfiguration(configuration)
+                .withPattern(PATTERN)
+                .build();
+
+        var strategy = DefaultRolloverStrategy.newBuilder()
+                .withMax(Integer.toString(Math.max(keepFiles, 1)))
+                .withConfig(configuration)
+                .build();
+
+        // Roll over on every server start, so each start gets its own file, and on size to keep them readable
+        var policy = CompositeTriggeringPolicy.createPolicy(
+                OnStartupTriggeringPolicy.createPolicy(1),
+                SizeBasedTriggeringPolicy.createPolicy(MAX_FILE_SIZE));
+
+        return RollingRandomAccessFileAppender.newBuilder()
+                .withFileName(directory.resolve(LATEST_LOG_NAME).toString())
+                .withFilePattern(directory.resolve(FILE_PATTERN).toString())
+                .withPolicy(policy)
+                .withStrategy(strategy)
+                .withName(APPENDER_NAME)
+                .withLayout(layout)
+                .withConfiguration(configuration)
+                .build();
+    }
+}

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/AdminNotificationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/AdminNotificationService.java
@@ -8,10 +8,14 @@ import net.onelitefeather.antiredstoneclockremastered.utils.Constants;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class AdminNotificationService implements NotificationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdminNotificationService.class);
 
     private final AntiRedstoneClockRemastered plugin;
     private final NotificationService notificationService;
@@ -42,10 +46,13 @@ public final class AdminNotificationService implements NotificationService {
             this.notificationService.sendNotificationMessage(location);
         }
         if (!isEnabled()) return;
+        var notified = 0;
         for (final Player player : Bukkit.getOnlinePlayers()) {
             if (!player.hasPermission(Constants.PERMISSION_NOTIFY) || !player.isOp()) continue;
             player.sendMessage(getNotificationMessage(location));
+            notified++;
         }
+        LOGGER.debug("Notified {} admins about the clock at {}", notified, location);
     }
 
     @Override

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/DiscordNotificationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/DiscordNotificationService.java
@@ -6,7 +6,6 @@ import club.minnced.discord.webhook.send.WebhookEmbedBuilder;
 import dev.vankka.mcdiscordreserializer.discord.DiscordSerializer;
 import dev.vankka.mcdiscordreserializer.discord.DiscordSerializerOptions;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
@@ -14,6 +13,8 @@ import net.onelitefeather.antiredstoneclockremastered.service.api.NotificationSe
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,7 +25,7 @@ import java.util.Map;
 
 public final class DiscordNotificationService implements NotificationService {
 
-    private static final ComponentLogger LOGGER = ComponentLogger.logger(DiscordNotificationService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiscordNotificationService.class);
     private final AntiRedstoneClockRemastered plugin;
     private final NotificationService notificationService;
     private final WebhookClient webhookClient;
@@ -77,7 +78,13 @@ public final class DiscordNotificationService implements NotificationService {
                 .setDescription(DiscordSerializer.INSTANCE.serialize(getNotificationMessage(location), DiscordSerializerOptions.defaults().withEscapeMarkdown(false)))
                 .setImageUrl(this.plugin.getConfig().getString("notification.discord.image", ""));
         generateFields(location).forEach(embed::addField);
-        this.webhookClient.send(embed.build()).thenAccept(message -> LOGGER.debug("Sent notification to Discord"));
+        this.webhookClient.send(embed.build())
+                .thenAccept(message -> LOGGER.debug("Sent notification for {} to Discord", location))
+                .exceptionally(throwable -> {
+                    LOGGER.warn("Could not send the notification to Discord, check the webhook url in the config.yml",
+                            throwable);
+                    return null;
+                });
     }
 
     public List<WebhookEmbed.EmbedField> generateFields(Location location) {

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/SignNotificationService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/notification/SignNotificationService.java
@@ -1,7 +1,6 @@
 package net.onelitefeather.antiredstoneclockremastered.service.notification;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.service.api.NotificationService;
@@ -9,9 +8,12 @@ import net.onelitefeather.antiredstoneclockremastered.service.api.RegionService;
 import net.onelitefeather.antiredstoneclockremastered.utils.Constants;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +21,7 @@ import java.util.Optional;
 
 public final class SignNotificationService implements NotificationService {
 
-    private static final ComponentLogger LOGGER = ComponentLogger.logger(SignNotificationService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SignNotificationService.class);
     private final AntiRedstoneClockRemastered plugin;
     private final NotificationService notificationService;
     private final RegionService regionService;
@@ -34,6 +36,19 @@ public final class SignNotificationService implements NotificationService {
         this.metaValue = new FixedMetadataValue(plugin, Constants.META_KEY_ARCR_SIGN);
         if (isEnabled()) {
             this.warnForTooLongText();
+            this.warnForWrongMaterial();
+        }
+    }
+
+    private void warnForWrongMaterial() {
+        var configured = this.plugin.getConfig().getString("notification.sign.material", "OAK_SIGN");
+        var material = Material.matchMaterial(configured);
+        if (material == null) {
+            LOGGER.warn("Unknown sign notification material '{}', falling back to OAK_SIGN", configured);
+            return;
+        }
+        if (!Tag.ALL_SIGNS.isTagged(material)) {
+            LOGGER.warn("The sign notification material '{}' is not a sign, no text can be placed on it", configured);
         }
     }
 
@@ -73,7 +88,10 @@ public final class SignNotificationService implements NotificationService {
             this.notificationService.sendNotificationMessage(location);
         }
         if (!isEnabled()) return;
-        if (!this.regionService.isRegionOwner(location)) return;
+        if (!this.regionService.isRegionOwner(location)) {
+            LOGGER.debug("Not placing a notification sign at {}, the region is owned by another thread", location);
+            return;
+        }
         this.regionService.executeInRegion(location, () -> {
             LOGGER.debug("Sending sign notification at {}", location);
             var blockMaterialString = this.plugin.getConfig().getString("notification.sign.material", "OAK_SIGN");
@@ -81,8 +99,9 @@ public final class SignNotificationService implements NotificationService {
             var block = location.getWorld().getBlockAt(location);
             block.setType(blockMaterial, false);
             var state = block.getState();
-            LOGGER.debug("Block state is {}", state);
-            if (state instanceof Sign sign) {
+            if (!(state instanceof Sign sign)) {
+                LOGGER.debug("Placed {} at {}, it carries no text because it is not a sign", blockMaterial, location);
+            } else {
                 sign.setMetadata(Constants.META_KEY_ARCR_SIGN, this.metaValue);
                 var side = sign.getSide(Side.BACK);
                 var lines = this.plugin.getConfig().getStringList("notification.sign.back")
@@ -105,7 +124,6 @@ public final class SignNotificationService implements NotificationService {
                 }
                 sign.update(true, false);
             }
-            LOGGER.debug("Updating sign at {}", location);
             block.getState().update();
         }, 2);
 

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DelegatedTrackingService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DelegatedTrackingService.java
@@ -7,9 +7,9 @@ import net.onelitefeather.antiredstoneclockremastered.model.RedstoneClock;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneTrackingService;
 import org.bukkit.Location;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,6 +33,10 @@ public final class DelegatedTrackingService implements RedstoneTrackingService {
     @Override
     public boolean isRedstoneClock(RedstoneClockMiddleware.CheckContext context) {
         var mode = ConfigMode.getEnum(this.plugin.getConfig(), "check.mode", ConfigMode.STATIC);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Delegating {} check at {} to the {} tracking service",
+                    context.eventType(), context.location(), mode);
+        }
         return switch (mode) {
             case STATIC -> this.staticTrackingService.isRedstoneClock(context);
             case DYNAMIC -> this.dynamicTrackingService.isRedstoneClock(context);

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DynamicTrackingService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/DynamicTrackingService.java
@@ -2,7 +2,6 @@ package net.onelitefeather.antiredstoneclockremastered.service.tracking;
 
 import com.jeff_media.customblockdata.CustomBlockData;
 import jakarta.inject.Inject;
-import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.model.DynamicRedstoneClock;
 import net.onelitefeather.antiredstoneclockremastered.model.RedstoneClock;
@@ -12,6 +11,8 @@ import net.onelitefeather.antiredstoneclockremastered.utils.UUIDTagType;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -22,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class DynamicTrackingService implements RedstoneTrackingService {
 
-    private static final ComponentLogger LOGGER = ComponentLogger.logger(DynamicTrackingService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DynamicTrackingService.class);
     private static final NamespacedKey REDSTONE_CLOCK_METADATA_KEY = NamespacedKey.fromString("antiredstoneclock:redstone_clock");
     private final ConcurrentHashMap<UUID, DynamicRedstoneClock> activeClockTesters = new ConcurrentHashMap<>();
     private final AntiRedstoneClockRemastered plugin;
@@ -64,10 +65,14 @@ public final class DynamicTrackingService implements RedstoneTrackingService {
 
     private boolean expireOrDestroyIfNeeded(@NotNull DynamicRedstoneClock clock) {
         if (clock.isTimeOut()) {
+            LOGGER.debug("Tracked block at {} timed out after {} triggers",
+                    clock.getCurrentLocation(), clock.getTriggerCount());
             removeClockByClock(clock);
             return false;
         }
         if (clock.getTriggerCount() >= plugin.getConfig().getInt("clock.maxCount", 150)) {
+            LOGGER.debug("Block at {} reached the trigger limit with {} triggers",
+                    clock.getCurrentLocation(), clock.getTriggerCount());
             removeClockByClock(clock);
             return true;
         }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/StaticTrackingService.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/service/tracking/StaticTrackingService.java
@@ -8,6 +8,8 @@ import net.onelitefeather.antiredstoneclockremastered.model.StaticRedstoneClock;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneClockMiddleware;
 import net.onelitefeather.antiredstoneclockremastered.service.api.RedstoneTrackingService;
 import org.bukkit.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,6 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named("staticTrackingService")
 public final class StaticTrackingService implements RedstoneTrackingService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StaticTrackingService.class);
 
     private final ConcurrentHashMap<Location, StaticRedstoneClock> activeClockTesters = new ConcurrentHashMap<>();
 
@@ -59,10 +63,12 @@ public final class StaticTrackingService implements RedstoneTrackingService {
 
     private boolean expireOrDestroyIfNeeded(@NotNull StaticRedstoneClock clock) {
         if (clock.isTimeOut()) {
+            LOGGER.debug("Tracked block at {} timed out after {} triggers", clock.getLocation(), clock.getTriggerCount());
             removeClockByClock(clock);
             return false;
         }
         if (clock.getTriggerCount() >= antiRedstoneClockRemastered.getConfig().getInt("clock.maxCount", 150)) {
+            LOGGER.debug("Block at {} reached the trigger limit with {} triggers", clock.getLocation(), clock.getTriggerCount());
             removeClockByClock(clock);
             return true;
         }

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/utils/CheckTPS.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/utils/CheckTPS.java
@@ -4,9 +4,13 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import net.onelitefeather.antiredstoneclockremastered.AntiRedstoneClockRemastered;
 import net.onelitefeather.antiredstoneclockremastered.service.api.SchedulerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public final class CheckTPS {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckTPS.class);
 
     private long lastPoll = System.currentTimeMillis();
     private boolean tpsOk = true;
@@ -26,8 +30,12 @@ public final class CheckTPS {
 
     public void startCheck() {
         if (this.minimumTPS > 0 || this.maximimumTPS > 0) {
+            LOGGER.debug("Starting TPS check every {} seconds, accepted range is {} to {}",
+                    this.interval, this.minimumTPS, this.maximimumTPS);
             this.scheduler.scheduleRepeatingTask(this::runCheck, 1, 20L * this.interval);
+            return;
         }
+        LOGGER.debug("TPS check is disabled, both tps.min and tps.max are negative");
     }
 
     private void runCheck() {
@@ -43,6 +51,7 @@ public final class CheckTPS {
             this.tpsOk = (this.tps >= this.minimumTPS && this.tps <= this.maximimumTPS);
         }
         this.lastPoll = current;
+        LOGGER.debug("Measured {} TPS, clock detection is {}", this.tps, this.tpsOk ? "running" : "paused");
     }
 
     public boolean isTpsOk() {

--- a/src/main/resources/antiredstoneclockremasterd.properties
+++ b/src/main/resources/antiredstoneclockremasterd.properties
@@ -27,6 +27,7 @@ antiredstoneclockremastered.command.feature.clock.toggle.notifyConsole.descripti
 antiredstoneclockremastered.command.feature.clock.toggle.drop.description=<gray>Turn the function of drop items on or off
 antiredstoneclockremastered.command.feature.clock.set.delay.description=<gray>Sets the desired value for the function
 antiredstoneclockremastered.command.feature.clock.set.maxCount.description=<gray>Sets the desired value for the function
+antiredstoneclockremastered.command.feature.debug.toggle.description=<gray>Turn debug logging into debug-logs/latest.log on or off
 antiredstoneclockremastered.notify.donation.console=<green>To keep the project alive, we ask for donations to our https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered
 antiredstoneclockremastered.notify.donation.player=<arg:0> <click:open_url:'https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered'><green>To keep the project alive, we ask for donations to our <blue>OpenCollective</click>
 antiredstoneclockremastered.notify.update.player=<arg:0> <yellow><click:open_url:'https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered'>Your version(<arg:1>) is older than our latest published version (<arg:2>). Please update as soon as possible to get continued support. Or click me to get on the download page!</click>

--- a/src/main/resources/antiredstoneclockremasterd_de_DE.properties
+++ b/src/main/resources/antiredstoneclockremasterd_de_DE.properties
@@ -27,6 +27,7 @@ antiredstoneclockremastered.command.feature.clock.toggle.notifyConsole.descripti
 antiredstoneclockremastered.command.feature.clock.toggle.drop.description=<gray>Schalte die Funktion der Drop-Items ein oder aus
 antiredstoneclockremastered.command.feature.clock.set.delay.description=<gray>Setzt den gewünschten Wert für die Funktion
 antiredstoneclockremastered.command.feature.clock.set.maxCount.description=<gray>Setzt den gewünschten Wert für die Funktion
+antiredstoneclockremastered.command.feature.debug.toggle.description=<gray>Schaltet das Debug-Logging in debug-logs/latest.log ein oder aus
 antiredstoneclockremastered.notify.donation.console=<green>Um das Projekt am Leben zu erhalten, bitten wir um Spenden an unsere https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered
 antiredstoneclockremastered.notify.donation.player=<arg:0> <click:open_url:'https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered'><green>Um das Projekt am Leben zu erhalten, bitten wir um Spenden an unsere <blue>OpenCollective</click>
 antiredstoneclockremastered.notify.update.player=<arg:0> <yellow><click:open_url:'https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered'>Ihre Version (<arg:1>) ist älter als unsere zuletzt veröffentlichte Version (<arg:2>). Bitte aktualisieren Sie so bald wie möglich, um weitere Support zu erhalten. Oder klicken Sie auf mich, um auf die Download-Seite zu gelangen!</click>

--- a/src/main/resources/antiredstoneclockremasterd_en_US.properties
+++ b/src/main/resources/antiredstoneclockremasterd_en_US.properties
@@ -27,6 +27,7 @@ antiredstoneclockremastered.command.feature.clock.toggle.notifyConsole.descripti
 antiredstoneclockremastered.command.feature.clock.toggle.drop.description=<gray>Turn the function of drop items on or off
 antiredstoneclockremastered.command.feature.clock.set.delay.description=<gray>Sets the desired value for the function
 antiredstoneclockremastered.command.feature.clock.set.maxCount.description=<gray>Sets the desired value for the function
+antiredstoneclockremastered.command.feature.debug.toggle.description=<gray>Turn debug logging into debug-logs/latest.log on or off
 antiredstoneclockremastered.notify.donation.console=<green>To keep the project alive, we ask for donations to our https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered
 antiredstoneclockremastered.notify.donation.player=<arg:0> <click:open_url:'https://opencollective.com/onelitefeather/projects/antiredstoneclock-remastered'><green>To keep the project alive, we ask for donations to our <blue>OpenCollective</click>
 antiredstoneclockremastered.notify.update.player=<arg:0> <yellow><click:open_url:'https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered'>Your version(<arg:1>) is older than our latest published version (<arg:2>). Please update as soon as possible to get continued support. Or click me to get on the download page!</click>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,13 @@ clock:
   notifyConsole: true
   drop: true
 
+# Debug messages are written to debug-logs/latest.log inside this directory,
+# they never show up in the server log.
+debug:
+  enabled: false
+  # How many rotated log files are kept next to latest.log
+  keepFiles: 5
+
 tps:
   interval: 2
   max: 20

--- a/src/test/java/net/onelitefeather/antiredstoneclockremastered/service/logging/DebugLoggingTest.java
+++ b/src/test/java/net/onelitefeather/antiredstoneclockremastered/service/logging/DebugLoggingTest.java
@@ -1,0 +1,187 @@
+package net.onelitefeather.antiredstoneclockremastered.service.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that the plugin log is wired into the Log4j2 setup of the server and that debug messages
+ * stay out of the appenders the server configured for itself.
+ */
+class DebugLoggingTest {
+
+    private static final String TEST_LOGGER = DebugLogging.PLUGIN_LOGGER_NAME + ".SomeService";
+
+    private LoggerContext context;
+    private CollectingAppender serverAppender;
+    private Level rootLevel;
+
+    @BeforeEach
+    void setUp() {
+        this.context = (LoggerContext) LogManager.getContext(false);
+        this.serverAppender = new CollectingAppender("CollectingServerAppender");
+        this.serverAppender.start();
+
+        var configuration = this.context.getConfiguration();
+        configuration.addAppender(this.serverAppender);
+
+        // Set up the root logger the way a server does it, the Log4j2 default would be ERROR
+        var rootLogger = configuration.getRootLogger();
+        this.rootLevel = rootLogger.getLevel();
+        rootLogger.setLevel(Level.INFO);
+        rootLogger.addAppender(this.serverAppender, null, null);
+        this.context.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        DebugLogging.disable();
+        var rootLogger = this.context.getConfiguration().getRootLogger();
+        rootLogger.removeAppender(this.serverAppender.getName());
+        rootLogger.setLevel(this.rootLevel);
+        this.serverAppender.stop();
+        this.context.updateLoggers();
+    }
+
+    @Test
+    @DisplayName("Debug messages are written to the plugin log")
+    void writesDebugMessages(@TempDir Path directory) throws IOException {
+        assertThat(DebugLogging.enable(directory, 3)).isTrue();
+
+        LogManager.getLogger(TEST_LOGGER).debug("a debug message");
+
+        assertThat(latestLog(directory)).contains("a debug message").contains("[SomeService]");
+    }
+
+    @Test
+    @DisplayName("Debug messages never reach the appenders of the server")
+    void keepsDebugMessagesOutOfTheServerLog(@TempDir Path directory) {
+        DebugLogging.enable(directory, 3);
+
+        var logger = LogManager.getLogger(TEST_LOGGER);
+        logger.debug("a debug message");
+        logger.info("an info message");
+        logger.warn("a warn message");
+
+        assertThat(this.serverAppender.messages())
+                .containsExactly("an info message", "a warn message")
+                .doesNotContain("a debug message");
+    }
+
+    @Test
+    @DisplayName("Warnings are written to the plugin log as well")
+    void copiesWarningsIntoThePluginLog(@TempDir Path directory) throws IOException {
+        DebugLogging.enable(directory, 3);
+
+        LogManager.getLogger(TEST_LOGGER).warn("a warn message", new IllegalStateException("boom"));
+
+        assertThat(latestLog(directory))
+                .contains("a warn message")
+                .contains("java.lang.IllegalStateException: boom");
+    }
+
+    @Test
+    @DisplayName("Loggers of other plugins are left alone")
+    void doesNotTouchOtherLoggers(@TempDir Path directory) {
+        DebugLogging.enable(directory, 3);
+
+        LogManager.getLogger("com.example.OtherPlugin").warn("from somewhere else");
+
+        assertThat(this.serverAppender.messages()).containsExactly("from somewhere else");
+    }
+
+    @Test
+    @DisplayName("Enabling is reported and can be checked")
+    void reportsItsState(@TempDir Path directory) {
+        assertThat(DebugLogging.isEnabled()).isFalse();
+
+        DebugLogging.enable(directory, 3);
+        assertThat(DebugLogging.isEnabled()).isTrue();
+
+        DebugLogging.disable();
+        assertThat(DebugLogging.isEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("After disabling, the plugin logger falls back to the server configuration")
+    void disableRestoresTheServerConfiguration(@TempDir Path directory) {
+        DebugLogging.enable(directory, 3);
+        DebugLogging.disable();
+
+        var logger = LogManager.getLogger(TEST_LOGGER);
+        logger.debug("a debug message");
+        logger.warn("a warn message");
+
+        assertThat(this.context.getConfiguration().getLoggers()).doesNotContainKey(DebugLogging.PLUGIN_LOGGER_NAME);
+        assertThat(this.serverAppender.messages()).containsExactly("a warn message");
+    }
+
+    @Test
+    @DisplayName("Disabling releases the log file")
+    void disableReleasesTheLogFile(@TempDir Path directory) throws IOException {
+        DebugLogging.enable(directory, 3);
+        LogManager.getLogger(TEST_LOGGER).debug("a debug message");
+
+        DebugLogging.disable();
+
+        // On Windows this only succeeds once Log4j2 has closed the file
+        assertThat(Files.deleteIfExists(directory.resolve(DebugLogging.LATEST_LOG_NAME))).isTrue();
+    }
+
+    @Test
+    @DisplayName("The log file is created inside the given directory")
+    void createsTheLogFile(@TempDir Path directory) {
+        var target = directory.resolve("debug-logs");
+
+        DebugLogging.enable(target, 3);
+        LogManager.getLogger(TEST_LOGGER).debug("a debug message");
+        DebugLogging.disable();
+
+        assertThat(target.resolve(DebugLogging.LATEST_LOG_NAME)).exists();
+    }
+
+    /**
+     * Reads the log file. Stopping the appender first, so its buffer ends up on disk.
+     */
+    private static String latestLog(Path directory) throws IOException {
+        DebugLogging.disable();
+        return Files.readString(directory.resolve(DebugLogging.LATEST_LOG_NAME));
+    }
+
+    /**
+     * Stands in for the appenders a server has configured for its own log.
+     */
+    private static final class CollectingAppender extends AbstractAppender {
+
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        private CollectingAppender(String name) {
+            super(name, null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            this.messages.add(event.getMessage().getFormattedMessage());
+        }
+
+        private List<String> messages() {
+            return this.messages;
+        }
+    }
+}


### PR DESCRIPTION
Closes #186

## What

The refactored classes barely logged anything, so there was no way to tell why a clock was or was not handled. This adds logging throughout them — and a place for the debug messages to go that is **not** the server log.

## How, using the server's own Log4j2

Paper logs through Log4j2, so that is what writes this file too — no hand-rolled writer, no own thread, no own rotation. `DebugLogging` attaches a `RollingRandomAccessFileAppender` (the same appender type the server uses for `logs/latest.log`) to a `LoggerConfig` for `net.onelitefeather.antiredstoneclockremastered`:

- the appender is bound at `DEBUG`, so debug messages land in the plugin log
- `additivity` is off and the server's own root appenders are re-attached at `INFO`, so debug never bubbles into the console or `logs/latest.log` while warnings and errors still do — and are written to the plugin log as well
- rollover happens on server start and past 10 MB, older files are compressed to `.log.gz`, `keepFiles` decides how many are kept

Everything else just uses `org.slf4j.Logger` as the plugin already did. `log4j-core` is `compileOnly` — the server provides it at runtime — and only the long-stable `withX` builder methods are used, so the plugin keeps working across the Log4j versions the supported Paper builds ship.

## Switching it on

```
/arcm feature debug
```

or in the `config.yml`:

```yaml
debug:
  enabled: false
  # How many rotated log files are kept next to latest.log
  keepFiles: 5
```

Both take effect immediately — the command and `/arcm reload` both run through `reloadPluginConfig()`, which re-applies the log setup. Written to `plugins/AntiRedstoneClock-Remastered/debug-logs/latest.log`, exactly as the issue asks. While debug is off the plugin logger just inherits the server log level, so `LOGGER.debug(...)` costs nothing but a level check.

## What is logged now

Debug: every middleware `SKIP` with its reason (ignored world, TPS out of range, WorldGuard/PlotSquared allows it, detection disabled for that block type), clock detection and removal, trigger limits and timeouts in both tracking services, TPS measurements, hopper cycles, translation loading, listener and chain setup, and which player changed which setting.

## Silent paths that got a voice

- `BukkitDecisionService` did nothing at all when `isRegionOwner` returned false — the clock silently stayed. Now a warning.
- The Discord webhook call had a `thenAccept` but no `exceptionally`, so send failures disappeared. Now a warning.
- A `notification.sign.material` that is not a sign produced a block with no text and no explanation. Now checked once at startup via `Tag.ALL_SIGNS`, so it does not spam per clock.
- A missing WorldGuard or PlotSquared was logged as `warn` although both are optional soft-depends. Downgraded to debug.
- `TranslationModule` logged a failing lang folder creation without the path or the exception.

## Notes for review

- `disable()` closes the appender's manager explicitly. Stopping the appender only drops a reference — the CI on Windows caught the file staying locked, and `disableReleasesTheLogFile` now covers it.
- `AntiRedstoneClockRemastered#reloadPluginConfig()` replaces the direct `reloadConfig()` call in `BukkitDecisionService#reload()` so the log setup follows a config reload.
- Only one debug call needs more than two format arguments on a hot path (`DelegatedTrackingService`); it is guarded with `isDebugEnabled()` to avoid the varargs array.
- One unused import (`ConfigurationSerialization`) was dropped from the plugin class while its import block was being edited.

## Tests

8 tests drive the real Log4j2 configuration: a collecting appender stands in for the server's own appenders and proves that debug messages never reach it while `INFO` and above still do, that other plugins' loggers are untouched, that `disable()` hands the loggers back, and that the log file is released. `./gradlew build` — green on Linux, macOS and Windows, 26 tests pass.