### PR TITLE
docs: improve README wording and correct outdated facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,23 @@ The goal of this plugin is to detect redstone clocks, inform staff or console ab
 
 ### Not a goal
 It's not planned to support Paper forks or Spigot directly - this plugin is developed to work on Paper, if you are using a fork of Paper or Spigot and it doesn't work because of your fork, you're likely on your own.
+Folia is the one exception: the plugin declares Folia support and there are dedicated Folia run tasks in the build.
 Also this plugin is not a "performance tool", it won't make your server run better directly.
 Support for Minecraft 1.13 and earlier is not planned.
 
 ## Minecraft Version Support
-Only the last 2 versions of a major Minecraft are supported.
-For Minecraft version 1.19, it would be 1.19.4,
-For Minecraft version 1.20, it would be 1.20.6 and so on
+The authoritative list is `supportedMinecraftVersions` in [`build.gradle.kts`](build.gradle.kts) - those are the versions we build and test against, and exactly that list is published to Hangar and Modrinth.
+
+At the time of writing it covers 1.20.6, every 1.21.x release up to 1.21.11, and 26.0 through 26.1.2.
+
+The plugin declares `api-version: 1.19`, so it may still load on older servers, but anything outside the list above is untested and unsupported.
 
 ## Features
-- 1.20+ Support
-- Java 21 support only
-- Plotsquared v6 and v7 support
-- WorldGuard Support
-- Ready for Minecraft 1.20 and 1.21 ready
+- Minecraft 1.20.6 up to 26.1.2 support
+- Java 25 required
+- Folia support
+- PlotSquared v6 and v7 support
+- WorldGuard v6 and v7 support
 - Clock detection
 - Sculk support
 - Hopper clock detection
@@ -42,18 +45,18 @@ For Minecraft version 1.20, it would be 1.20.6 and so on
 
 ## Contribution
 You want to help us? Sure, go for it!
-We would love to see your contribution! You can look for open issues or if you have a new idea, please open an issue or ask us on Discord if you can submit your feature with a PR. Communication is a key.
+We would love to see your contribution! You can look for open issues or if you have a new idea, please open an issue or ask us on Discord if you can submit your feature with a PR. Communication is key.
 
 ## Dependencies (soft-depend, can be used together)
-- PlotSquared v7 https://github.com/IntellectualSites/PlotSquared
-- WorldGuard v7 https://github.com/EngineHub/WorldGuard
+- PlotSquared v6 and v7 https://github.com/IntellectualSites/PlotSquared
+- WorldGuard v6 and v7 https://github.com/EngineHub/WorldGuard
 
 ## Permissions:
 ```
 antiredstoneclockremastered.notify.admin
 ```
 > [!CAUTION]
-> All others can be found in plugin.yml or use LuckPerms, which are automatically suggested there
+> All other permissions are declared in the `paper { permissions { ... } }` block in [`build.gradle.kts`](build.gradle.kts) and end up in the generated `plugin.yml` inside the jar. There is no `plugin.yml` to read in this repository. LuckPerms picks them up from the jar and suggests them automatically.
 
 ## Commands
 - /arcm reload
@@ -61,7 +64,7 @@ antiredstoneclockremastered.notify.admin
 - /arcm help
   - Shows all commands and descriptions
 - /arcm display
-  - Display the currently cached redstone clocks
+  - Displays the currently cached redstone clocks
 
 ## More information / external links / Download
 Hangar: https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@
 
 This plugin is inspired by https://gitlab.com/Trafalcraft/antiRedstoneClock
 
-We re-created the whole code and improved everything. On top, we support Plotsquared v7 and Worldguard v7.
+We re-created the whole code and improved everything. Additionally, we support PlotSquared v7 and WorldGuard v7.
 
 ### Goal
-The goal of this plugin is to detect redstone clocks, inform staff or console about active ones and optionally destroy / disable the redstone clocks so your server can save performance for something else. Also it can prevent players doing harm with heavy clocks, but this is more of a side effect.
+The goal of this plugin is to detect redstone clocks, inform staff or console about active ones and optionally destroy / disable the redstone clocks so your server can save performance for something else. It can also prevent players from causing harm with heavy redstone clocks, but this is more of a side effect.
 
 ### Not a goal
-It's not planned to support Paper forks or spigot directly - this plugin is developed to work on Paper, if you are using a fork of paper or spigot and it doesn't work because of your fork, you are likely on your own then.
+It's not planned to support Paper forks or Spigot directly - this plugin is developed to work on Paper, if you are using a fork of Paper or Spigot and it doesn't work because of your fork, you're likely on your own.
 Also this plugin is not a "performance tool", it won't make your server run better directly.
-Third, support from 1.13 backwards likely won't happen.
+Support for Minecraft 1.13 and earlier is not planned.
 
 ## Minecraft Version Support
 Only the last 2 versions of a major Minecraft are supported.
@@ -27,40 +27,41 @@ For Minecraft version 1.20, it would be 1.20.6 and so on
 
 ## Features
 - 1.20+ Support
-- Java 21 only support
+- Java 21 support only
 - Plotsquared v6 and v7 support
 - WorldGuard Support
-- 1.20,1.21 ready
+- Ready for Minecraft 1.20 and 1.21 ready
 - Clock detection
 - Sculk support
 - Hopper clock detection
-- Config Migration(Soon)
+- Config Migration (Coming Soon)
 - Prevent duplicated loading of anti-redstoneclock plugins
 
 > [!CAUTION]
-> The "world" world is ignored by default
+> The "world" world is ignored by default.
 
 ## Contribution
-You want to help us? Sure go for it, we would love to see your contribution! You can look for open issues or if you have a nice idea, please open an issue or ask us on discord if you can add your feature with a PR. Communication is key.
+You want to help us? Sure, go for it!
+We would love to see your contribution! You can look for open issues or if you have a new idea, please open an issue or ask us on Discord if you can submit your feature with a PR. Communication is a key.
 
 ## Dependencies (soft-depend, can be used together)
-- Plotsquared v7 https://github.com/IntellectualSites/PlotSquared
-- Worldguard v7 https://github.com/EngineHub/WorldGuard
+- PlotSquared v7 https://github.com/IntellectualSites/PlotSquared
+- WorldGuard v7 https://github.com/EngineHub/WorldGuard
 
 ## Permissions:
 ```
 antiredstoneclockremastered.notify.admin
 ```
 > [!CAUTION]
-> All others can be taken from the Plugin.yml or use LuckPerms, which are automatically suggested there
+> All others can be found in plugin.yml or use LuckPerms, which are automatically suggested there
 
-## Commmands
+## Commands
 - /arcm reload
   - Reloads the config
 - /arcm help
   - Shows all commands and descriptions
 - /arcm display
-  - Shows current cached redstone clocks
+  - Display the currently cached redstone clocks
 
 ## More information / external links / Download
 Hangar: https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered


### PR DESCRIPTION
Supersedes #253.

This is @2501030072-blip's README cleanup from #253, rebased onto current `main` and followed by a review pass that fixes the parts which were inaccurate or based on the stale branch point.

## Commit 1 — `docs: improve README wording and fix typos` (@2501030072-blip)

Cherry-picked from #253, authorship preserved, commit message reworded to satisfy `pr-lint`. Applied only the parts that are strict improvements:

- `Commmands` → `Commands`
- Official casing: PlotSquared, WorldGuard, Spigot, Paper, Discord
- "prevent players **from causing** harm", "you're likely on your own", "Additionally, we support …"
- `Config Migration(Soon)` → `Config Migration (Coming Soon)`
- Missing sentence period in the CAUTION callout

Deliberately **not** carried over from #253:

- The rewrite of the Release Cycle section — #253 branched off `2.8.7`, before cd5013c, and would have reverted the Release Please documentation back to `semantic-release`.
- The deletion of the `- Hopper clock detection` bullet, for the same reason (#271).
- `Commits with` → `Commits of`, which is a grammar regression on three of the five bullets.
- The Minecraft version support rewrite, which was self-contradictory ("last two minor releases" followed by exactly one example) and factually wrong. Fixed properly in commit 2 instead.

## Commit 2 — `docs: correct outdated facts in README`

Everything here is checked against the build, not just reworded:

| Claim | Reality | Source |
|---|---|---|
| "Only the last 2 versions of a major Minecraft are supported" | 1.20.6, all 1.21.x through 1.21.11, 26.0–26.1.2 — and that exact list is what gets published | `build.gradle.kts:30-47`, `:270` |
| "Java 21 only support" | Toolchain is Java 25, no `release`/`targetCompatibility` override | `build.gradle.kts:58` |
| "WorldGuard Support" | v6 **and** v7 modules are built and shaded in | `settings.gradle.kts`, `build.gradle.kts:82-85` |
| "no Paper forks" | Folia is explicitly supported | `build.gradle.kts:179`, `run-folia-*` tasks |
| "can be found in plugin.yml" | No `plugin.yml` in the repo — it is generated from the `paper {}` block | `build.gradle.kts:175-247` |

Plus the leftover language issues: the duplicated `ready` in "Ready for Minecraft 1.20 and 1.21 ready", "Communication is a key", and `Display` → `Displays` to match the neighbouring command descriptions.

The version section now points at `supportedMinecraftVersions` as the single source of truth rather than restating a matrix that goes stale on every release.

## Note

The Release Cycle section is byte-for-byte untouched.