### PR TITLE
ci: harden issue intake and document token-free board tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -4,14 +4,61 @@ labels: [ "status: needs triage", "type: bug" ]
 projects: ["OneLiteFeatherNET/6"]
 assignees: ["OneLiteFeatherNET/antiredstoneclock-remastered-triage"]
 body:
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before you continue
+      description: We close reports that skip these. Please tick every box.
+      options:
+        - label: I am running the latest version of AntiRedstoneClock-Remastered from [Hangar](https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered) or [Modrinth](https://modrinth.com/plugin/AntiRedstoneClock-Remastered).
+          required: true
+        - label: I am running a Minecraft version that is listed as supported in the [README](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered#minecraft-version-support).
+          required: true
+        - label: I searched the open and closed issues and this is not a duplicate.
+          required: true
+        - label: I am pasting unmodified console output, not screenshots and not a summary.
+          required: true
+
+  - type: dropdown
+    id: server-software
+    attributes:
+      label: Server software
+      description: |
+        We support Paper and Folia. Paper forks, Spigot, CraftBukkit and hybrid servers are not supported -
+        see [Not a goal](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered#not-a-goal).
+        Reports for unsupported software are closed automatically.
+      options:
+        - Paper
+        - Folia
+        - A Paper fork (Purpur, Pufferfish, Leaves, ...)
+        - Spigot or CraftBukkit
+        - A hybrid server (Mohist, Arclight, Magma, Banner, ...)
+        - Something else
+    validations:
+      required: true
+
+  - type: input
+    id: log-link
+    attributes:
+      label: Full log (paste service)
+      description: |
+        Upload your full `logs/latest.log` to [mclo.gs](https://mclo.gs) and paste the link here.
+        This is the fastest way for us to help you - a link keeps the whole log intact and readable.
+      placeholder: https://mclo.gs/xxxxxxx
+    validations:
+      required: false
+
   - type: textarea
     id: server-logs
     attributes:
       label: Server Logs
       description: |
-        Upload your server log from `logs/latest.log` here
+        Paste the relevant part of `logs/latest.log` here, including the full stack trace if there is one.
+        Do not reformat or shorten the lines - this field is turned into a code block automatically.
+      render: text
     validations:
       required: true
+
   - type: textarea
     id: expected-behavior
     attributes:
@@ -43,6 +90,7 @@ body:
       description: |
         All plugins and datapacks running on your server.
         To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
+      render: text
     validations:
       required: true
 
@@ -54,20 +102,12 @@ body:
         Run `/version` on your server and **paste** the full, unmodified output here.
         "latest" is *not* a version; we require the output of `/version` so we can adequately track down the issue.
         Additionally, do NOT provide a screenshot, you MUST paste the entire output.
-        <details>
-        <summary>Example</summary>
-
-        ```
-        > version
-        [19:36:32 INFO]: Checking version, please wait...
-        [19:36:32 INFO]: This server is running Paper version 1.20.6-148-ver/1.20.6@20f5165 (2024-07-02T15:37:33Z) (Implementing API version 1.20.6-R0.1-SNAPSHOT)
-        You are running the latest version
-        Previous version: git-Paper-446 (MC: 1.19.3)
-        ```
-
-        </details>
+        Example:
+        `[19:36:32 INFO]: This server is running Paper version 1.20.6-148-ver/1.20.6@20f5165 (2024-07-02T15:37:33Z) (Implementing API version 1.20.6-R0.1-SNAPSHOT)`
+      render: text
     validations:
       required: true
+
   - type: textarea
     id: plugin-version
     attributes:
@@ -76,18 +116,12 @@ body:
         Run `/about AntiRedstoneClock-Remastered` on your server and **paste** the full, unmodified output here.
         "latest" is *not* a version; we require the output of `/about AntiRedstoneClock-Remastered` so we can adequately track down the issue.
         Additionally, do NOT provide a screenshot, you MUST paste the entire output.
-        <details>
-        <summary>Example</summary>
-
-        ```
-        > about AntiRedstoneClock-Remastered
-        [19:37:16 INFO]: AntiRedstoneClock-Remastered version 1.1.0
-        [19:37:16 INFO]: Authors: OneLiteFeather and TheMeinerLP
-        ```
-
-        </details>
+        Example:
+        `[19:37:16 INFO]: AntiRedstoneClock-Remastered version 1.1.0`
+      render: text
     validations:
       required: true
+
   - type: textarea
     id: other-information
     attributes:
@@ -97,14 +131,3 @@ body:
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
     validations:
       required: false
-
-  - type: markdown
-    id: pre-submission-checklist
-    attributes:
-      value: |
-        Before submitting this issue, please ensure the following:
-
-        1. You are running the latest version of Paper from [our downloads page](https://papermc.io/downloads).
-        2. You searched for and ensured there isn't already an open issue regarding this.
-        3. Your version of Minecraft is supported by AntiRedstoneClock-Remastered.
-        4. You are running the latest version of AntiRedstoneClock-Remastered from [our hangar page](https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered).

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,328 @@
+name: Issue triage
+
+# Harden the bug-report intake. Every bug report is checked for the three
+# things that used to cost the most triage time: unreadable logs, servers we
+# do not support, and versions that are already fixed or out of scope.
+#
+# The workflow never deletes user content. It labels, explains what is wrong
+# in a single sticky comment, and only closes an issue when the reporter is on
+# server software this project explicitly does not support.
+
+"on":
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Validate bug report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only bug reports carry a "Server Logs" section. Feature requests and
+    # manually opened issues are left alone.
+    if: contains(github.event.issue.body, '### Server Logs')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const MARKER = '<!-- arcm-issue-triage -->';
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            // --- helpers -------------------------------------------------
+
+            // Issue forms render as "### Heading\n\ncontent". Split on the
+            // headings so each answer can be looked up by its label.
+            function parseSections(text) {
+              const out = {};
+              for (const part of text.split(/^### +/m).slice(1)) {
+                const nl = part.indexOf('\n');
+                if (nl === -1) continue;
+                out[part.slice(0, nl).trim()] = part.slice(nl + 1).trim();
+              }
+              return out;
+            }
+
+            // Strip the code fence that `render:` adds so the contents can be
+            // pattern matched, while remembering whether a fence was there.
+            function unfence(value) {
+              if (!value) return { text: '', fenced: false };
+              const m = value.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+              return m ? { text: m[1], fenced: true } : { text: value, fenced: false };
+            }
+
+            const isBlank = (v) => !v || !v.trim() || /^_No response_$/i.test(v.trim());
+
+            const sections = parseSections(body);
+            const logs = unfence(sections['Server Logs']);
+            const paperVersion = unfence(sections['Paper version']);
+            const pluginVersion = unfence(sections['Plugin version']);
+            const softwareAnswer = (sections['Server software'] || '').trim();
+            const logLink = (sections['Full log (paste service)'] || '').trim();
+
+            // Everything the reporter pasted about their server, in one blob.
+            const haystack = [logs.text, paperVersion.text, pluginVersion.text].join('\n');
+
+            const problems = [];
+            const labelsToAdd = new Set();
+            const labelsToRemove = new Set();
+            let closeAsUnsupported = false;
+
+            // --- 1. server software --------------------------------------
+
+            const SUPPORTED = ['paper', 'folia'];
+            const FORKS = [
+              'purpur', 'pufferfish', 'airplane', 'tuinity', 'yatopia', 'gale',
+              'leaves', 'divinemc', 'luminol', 'canvas', 'plazma', 'petal',
+              'mirai', 'sugarcane', 'patina', 'scissors', 'kaiiju', 'pearl',
+              'spigot', 'craftbukkit', 'bukkit', 'glowstone',
+              'mohist', 'magma', 'arclight', 'banner', 'ketting', 'catserver',
+              'thermos', 'crucible', 'uranium', 'youer',
+              'sponge', 'forge', 'fabric', 'neoforge', 'quilt',
+            ];
+
+            // The "This server is running X version" line is authoritative -
+            // it is printed by the server itself and cannot be mistyped.
+            let detected = null;
+            const running = haystack.match(/This server is running ([A-Za-z0-9_.-]+) version/i);
+            if (running) {
+              detected = running[1].toLowerCase();
+            } else {
+              const bootstrap = haystack.match(/\[bootstrap\][^\n]*Loading ([A-Za-z0-9_.-]+) /i);
+              if (bootstrap) detected = bootstrap[1].toLowerCase();
+            }
+
+            const dropdownUnsupported = /^(A Paper fork|Spigot or CraftBukkit|A hybrid server|Something else)/i
+              .test(softwareAnswer);
+
+            const notAGoal =
+              `[Not a goal](https://github.com/${context.repo.owner}/${context.repo.repo}#not-a-goal)`;
+            const reproduce =
+              'Please reproduce the problem on Paper or Folia and open a new report if it still happens.';
+
+            if (detected && SUPPORTED.includes(detected)) {
+              // Paper or Folia - nothing to do.
+            } else if (detected && FORKS.includes(detected)) {
+              const pretty = detected.charAt(0).toUpperCase() + detected.slice(1);
+              problems.push(
+                `**Unsupported server software.** Your log says the server is running \`${pretty}\`. ` +
+                `This plugin targets Paper and Folia only - see ${notAGoal}. ${reproduce}`
+              );
+              closeAsUnsupported = true;
+            } else if (dropdownUnsupported) {
+              problems.push(
+                `**Unsupported server software.** You selected \`${softwareAnswer}\`. ` +
+                `This plugin targets Paper and Folia only - see ${notAGoal}. ${reproduce}`
+              );
+              closeAsUnsupported = true;
+            } else if (detected) {
+              // Something we do not recognise. Closing on a guess would be
+              // worse than a human spending ten seconds on it, so only flag.
+              const pretty = detected.charAt(0).toUpperCase() + detected.slice(1);
+              problems.push(
+                `**Unrecognised server software.** Your log says the server is running \`${pretty}\`, ` +
+                `which we do not know. We support Paper and Folia - see ${notAGoal}. ` +
+                `If this is a Paper fork, the report cannot be accepted; if the detection is wrong, ` +
+                `please paste the unmodified output of \`/version\`.`
+              );
+            }
+
+            // --- 2. log formatting and completeness ----------------------
+
+            if (isBlank(logs.text) && !logLink) {
+              problems.push(
+                '**No logs.** Attach your `logs/latest.log` - either paste it into the ' +
+                '*Server Logs* field or upload it to [mclo.gs](https://mclo.gs) and put the link ' +
+                'in the *Full log* field.'
+              );
+            } else if (!logs.fenced && logs.text.split('\n').length > 2) {
+              // Pasted through the old template (or hand-written): the log is
+              // sitting in the body as raw Markdown, which mangles it.
+              problems.push(
+                '**Unreadable log formatting.** Your log was posted as plain Markdown, so ' +
+                'timestamps, brackets and stack-trace indentation are mangled. Please edit the ' +
+                'issue and wrap the log in a fenced code block:\n\n' +
+                '````\n```text\n[12:34:56] [Server thread/INFO]: ...\n```\n````\n\n' +
+                'Better still, upload the full file to [mclo.gs](https://mclo.gs) and paste the link.'
+              );
+            }
+
+            for (const [heading, value] of Object.entries({
+              'Expected behavior': sections['Expected behavior'],
+              'Actual behavior': sections['Actual behavior'],
+              'Steps to reproduce': sections['Steps to reproduce'],
+            })) {
+              if (isBlank(value)) problems.push(`**Missing \`${heading}\`.** This field is required.`);
+            }
+
+            // --- 3. Minecraft version ------------------------------------
+
+            // build.gradle.kts is the single source of truth: this same list is
+            // what gets published to Hangar and Modrinth.
+            let supportedVersions = [];
+            try {
+              const gradle = fs.readFileSync('build.gradle.kts', 'utf8');
+              const block = gradle.match(/val supportedMinecraftVersions = listOf\(([\s\S]*?)\n\)/);
+              if (block) supportedVersions = [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+            } catch (err) {
+              core.warning(`Could not read supported versions: ${err.message}`);
+            }
+
+            let mcVersion = null;
+            const patterns = [
+              /for Minecraft ([0-9][0-9A-Za-z.\-]*)/i,
+              /Implementing API version ([0-9]+\.[0-9]+(?:\.[0-9]+)?)/i,
+              /running [A-Za-z]+ version ([0-9]+\.[0-9]+(?:\.[0-9]+)?)/i,
+            ];
+            for (const re of patterns) {
+              const m = haystack.match(re);
+              if (m) { mcVersion = m[1]; break; }
+            }
+
+            if (mcVersion && supportedVersions.length) {
+              if (supportedVersions.includes(mcVersion)) {
+                labelsToAdd.add(`Game Version: ${mcVersion}`);
+              } else {
+                labelsToAdd.add('legacy');
+                problems.push(
+                  `**Unsupported Minecraft version.** Your server reports \`${mcVersion}\`, which is ` +
+                  `not in our supported list. We currently build and publish for: ` +
+                  `${supportedVersions.map((v) => `\`${v}\``).join(', ')}.`
+                );
+              }
+            }
+
+            // --- 4. plugin version ---------------------------------------
+
+            let reportedPlugin = null;
+            const pluginPatterns = [
+              /AntiRedstoneClock-Remastered version ([0-9]+\.[0-9]+\.[0-9]+)/i,
+              /AntiRedstoneClock-Remastered[ -]v?([0-9]+\.[0-9]+\.[0-9]+)/i,
+              /AntiRedstoneClock-Remastered \(([0-9]+\.[0-9]+\.[0-9]+)\)/i,
+            ];
+            for (const re of pluginPatterns) {
+              const m = [pluginVersion.text, haystack].join('\n').match(re);
+              if (m) { reportedPlugin = m[1]; break; }
+            }
+
+            if (reportedPlugin) {
+              labelsToAdd.add(`Plugin Version: ${reportedPlugin}`);
+              try {
+                const latest = await github.rest.repos.getLatestRelease({ ...context.repo });
+                const latestVersion = latest.data.tag_name.replace(/^v/, '');
+                const cmp = (a, b) => {
+                  const pa = a.split('.').map(Number);
+                  const pb = b.split('.').map(Number);
+                  for (let i = 0; i < 3; i++) {
+                    if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+                  }
+                  return 0;
+                };
+                if (cmp(reportedPlugin, latestVersion) < 0) {
+                  problems.push(
+                    `**Outdated plugin version.** You are on \`${reportedPlugin}\`, the latest release ` +
+                    `is \`${latestVersion}\`. Please update and check whether the problem still occurs ` +
+                    `before we spend time on it.`
+                  );
+                }
+              } catch (err) {
+                core.warning(`Could not read latest release: ${err.message}`);
+              }
+            } else if (!isBlank(pluginVersion.text)) {
+              problems.push(
+                '**Could not read your plugin version.** Please paste the raw output of ' +
+                '`/about AntiRedstoneClock-Remastered` into the *Plugin version* field.'
+              );
+            }
+
+            // --- apply ----------------------------------------------------
+
+            if (problems.length) {
+              labelsToAdd.add('user response');
+            } else {
+              labelsToRemove.add('user response');
+            }
+            if (closeAsUnsupported) {
+              // Do not ask for more information on a report we are closing.
+              labelsToAdd.add('resolution: invalid');
+              labelsToAdd.delete('user response');
+              labelsToRemove.add('user response');
+            }
+
+            if (labelsToAdd.size) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: [...labelsToAdd],
+              });
+            }
+            for (const name of labelsToRemove) {
+              if (!issue.labels.some((l) => l.name === name)) continue;
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: issue.number,
+                name,
+              }).catch(() => {});
+            }
+
+            // One sticky comment that gets rewritten, instead of a new comment
+            // on every edit.
+            const heading = closeAsUnsupported
+              ? '### This report cannot be accepted\n'
+              : '### This report needs a few fixes before we can look at it\n';
+            const wanted = problems.length
+              ? `${MARKER}\n${heading}\n` +
+                problems.map((p) => `- ${p}`).join('\n\n') +
+                '\n\nEdit the issue to fix these - this check runs again automatically on every edit.'
+              : `${MARKER}\n### Automated checks passed\n\nThanks, everything we need is here. ` +
+                'A maintainer will pick this up.';
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+            const mine = existing.find((c) => c.body && c.body.includes(MARKER));
+
+            if (mine) {
+              if (mine.body.trim() !== wanted.trim()) {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: mine.id,
+                  body: wanted,
+                });
+              }
+            } else if (problems.length) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: wanted,
+              });
+            }
+
+            if (closeAsUnsupported && issue.state === 'open') {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }
+
+            core.summary
+              .addHeading(`Triage for #${issue.number}`, 3)
+              .addRaw(problems.length ? `${problems.length} problem(s) found.` : 'All checks passed.')
+              .write();

--- a/docs/ISSUE_INTAKE.md
+++ b/docs/ISSUE_INTAKE.md
@@ -1,0 +1,143 @@
+# Issue intake pipeline
+
+How a bug report gets from "someone hit submit" to "a maintainer can act on it",
+and what is automated along the way.
+
+## The three problems this solves
+
+1. **Unreadable logs.** The bug template used to collect logs in a plain
+   `textarea`. GitHub renders that as Markdown, so timestamps, square brackets
+   and stack-trace indentation get mangled and the log becomes unusable. See
+   [#267](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/issues/267).
+2. **Unsupported server software.** Reports from Paper forks, Spigot,
+   CraftBukkit and hybrid servers cost triage time for something we do not
+   support. See [Not a goal](../README.md#not-a-goal).
+3. **Issues never reaching the board.** The `projects:` key in an issue form
+   only applies when the person opening the issue has write access to the
+   project. For outside reporters it is silently ignored, which is why reports
+   like #266 and #267 never appeared on the roadmap. Fixed by the project's
+   own auto-add automation, which is described under [Board sync](#board-sync).
+
+## What runs, and when
+
+| Stage | Where it lives | Trigger |
+|---|---|---|
+| Form validation | `.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml` | at submit time, in the browser |
+| Content checks | `.github/workflows/issue-triage.yml` | `issues: opened, edited, reopened` |
+| Board sync | built-in project automations, configured in the project UI | issue created, closed, reopened |
+
+### Form validation
+
+Enforced by GitHub before the issue is created:
+
+- Four required acknowledgement checkboxes (latest version, supported Minecraft
+  version, searched for duplicates, pasting text not screenshots).
+- A required **Server software** dropdown, so the answer exists even when the
+  log is missing.
+- `render: text` on every field that receives console output. GitHub wraps
+  those in a fenced code block automatically, which is the actual fix for the
+  mangled-log problem — the reporter cannot get it wrong any more.
+- An optional [mclo.gs](https://mclo.gs) link field for the full log.
+
+### Content checks
+
+`issue-triage.yml` only runs on issues that contain a `### Server Logs`
+section, so feature requests are untouched. It never edits or deletes user
+content. It:
+
+- detects the server software from the `This server is running X version` line
+  the server prints itself. The log outranks the dropdown, so a mis-click does
+  not get a Paper user rejected. Detection is deliberately three-way:
+  Paper/Folia passes, a name on the known-fork list is closed, and anything
+  unrecognised is only flagged for a human — closing on a guess is worse than
+  ten seconds of triage;
+- verifies the log is in a code block and is actually present;
+- compares the reported Minecraft version against `supportedMinecraftVersions`
+  in `build.gradle.kts` — the same list that gets published to Hangar and
+  Modrinth, so there is one source of truth and no second list to keep in sync;
+- compares the reported plugin version against the latest GitHub release;
+- writes its findings into **one sticky comment** that is rewritten on every
+  edit, rather than piling up new comments.
+
+Outcomes:
+
+| Finding | Label | Closed |
+|---|---|---|
+| Known Paper fork, Spigot, CraftBukkit, hybrid server | `resolution: invalid` | yes, as *not planned* |
+| Server software we do not recognise | `user response` | no |
+| Log missing, or not in a code block | `user response` | no |
+| Required field empty | `user response` | no |
+| Minecraft version not in the supported list | `legacy` + `user response` | no |
+| Plugin version older than the latest release | `user response` | no |
+| Everything in order | `Game Version: x`, `Plugin Version: x` | no |
+
+Closing only happens for unsupported server software. Everything else stays
+open and gets a `user response` label, which is cleared automatically once the
+reporter edits the issue into shape.
+
+### Board sync
+
+Board sync deliberately uses **no Actions workflow and no token**. It runs on
+the built-in automations of
+[the roadmap project](https://github.com/orgs/OneLiteFeatherNET/projects/6),
+which GitHub evaluates server-side. Because they belong to the project rather
+than to the person opening the issue, they work for outside reporters too -
+which is exactly the gap that left #266 and #267 off the board.
+
+A workflow could not do this without a credential anyway: `GITHUB_TOKEN`
+cannot write to organisation projects, so any Actions-based approach needs a
+PAT or App token.
+
+Four automations are enabled on the project. Together they cover the whole
+lifecycle:
+
+| Automation | Filter | Effect |
+|---|---|---|
+| Auto-add to project | `is:issue is:open` on this repository | puts new issues on the board |
+| Item added to project | — | sets Status to New |
+| Item closed | — | sets Status to Done |
+| Item reopened | — | moves the item back out of Done |
+
+To inspect or change them: project → kebab menu → **Workflows**.
+
+Why the filter is `is:issue is:open` and not just `is:issue`: the auto-add
+automation fires on new **or updated** items. With a bare `is:issue`, a
+long-closed issue that merely receives a comment would be pulled onto the
+board, and "Item added to project" would stamp it Status **New** — a resolved
+issue reappearing as fresh work. Restricting to `is:open` avoids that;
+reopened issues still come back in through "Item reopened".
+
+Two things to keep in mind:
+
+- **Auto-add is not retroactive.** It only reacts to issues created or updated
+  after it was switched on. Issues that were already open at that point were
+  added once by hand — at the time of writing that was only #267.
+- **The organisation is on the Free plan, which allows exactly one auto-add
+  automation per project.** There is no budget for several narrower ones, so
+  the single broad filter above has to cover everything. Pro and Team raise
+  this to five.
+
+These automations cannot be committed to the repository - the GraphQL API
+exposes `deleteProjectV2Workflow` but no create or update counterpart, so the
+project UI is the only place to configure them. That also means a reviewer
+cannot see them in this repository; the query below prints the live state:
+
+```bash
+gh api graphql -f query='
+query { organization(login: "OneLiteFeatherNET") { projectV2(number: 6) {
+  workflows(first: 30) { nodes { name enabled } } } } }'
+```
+
+The `projects:` key is still present in both issue templates. It is harmless
+and adds the issue immediately for anyone who has write access to the project,
+but it is **not** what makes tracking work - do not remove the auto-add
+automation on the assumption that the template covers it.
+
+## Changing the rules
+
+- **Supported Minecraft versions**: edit `supportedMinecraftVersions` in
+  `build.gradle.kts`. Triage, Hangar and Modrinth all read that one list.
+- **Supported or rejected server software**: the `SUPPORTED` and `FORKS`
+  arrays in `issue-triage.yml`.
+- **Wording of the automated comment**: the `problems.push(...)` calls in the
+  same file.


### PR DESCRIPTION
Closes the gap that #267 exposed. **No token, no secret** — board tracking runs on the project's own automations, which are already switched on.

## What was wrong

#267 is three separate intake failures in one issue:

1. **The log is unreadable.** The `Server Logs` field was a plain `textarea`, so GitHub rendered the console output as Markdown — timestamps, brackets and stack-trace indentation all mangled.
2. **The versions are out of scope.** The reporter is on Minecraft `26.2` (our supported list stops at `26.1.2`) running plugin `2.8.3` (current release: `2.8.9`). Nobody noticed until a human read the whole log.
3. **It never reached the board.** Both templates already carry `projects: ["OneLiteFeatherNET/6"]`, but that key only applies when the issue author has write access to the project. Verified: #266 and #267 (outside reporter) had `projects=0`, #230 (org member) had `projects=1`.

## Code in this PR

### `behavior-bug-or-plugin-incompatibility.yml`

- `render: text` on every field that receives console output. This is the actual fix for #267 — GitHub wraps the content in a fenced code block automatically, so the reporter cannot get it wrong.
- Required **Server software** dropdown, so the answer exists even when the log is missing.
- Four required acknowledgement checkboxes, replacing the markdown checklist that sat at the *bottom* of the form where nobody read it.
- Optional [mclo.gs](https://mclo.gs) link field for the full log.

### `issue-triage.yml` (new)

Runs on `issues: opened, edited, reopened`, gated on the presence of a `### Server Logs` section so feature requests are untouched. Uses only the built-in `GITHUB_TOKEN`. Never edits or deletes user content.

| Finding | Label | Closed |
|---|---|---|
| Known fork / Spigot / CraftBukkit / hybrid | `resolution: invalid` | yes, *not planned* |
| Unrecognised server software | `user response` | no |
| Log missing or not in a code block | `user response` | no |
| Required field empty | `user response` | no |
| Minecraft version unsupported | `legacy` + `user response` | no |
| Plugin version outdated | `user response` | no |
| All good | `Game Version: x`, `Plugin Version: x` | no |

Design decisions worth reviewing:

- **The supported-version list is read from `build.gradle.kts` at runtime**, not duplicated into the workflow. Same list that feeds `hangarPublish`, so there is no second source to keep in sync.
- **Detection is three-way, not an allowlist.** Paper/Folia passes, a name on the known-fork list is closed, anything unrecognised is only flagged. An allowlist would auto-close a valid report whenever the regex caught something unexpected.
- **The log outranks the dropdown.** A mis-click does not get a Paper user rejected.
- **One sticky comment**, rewritten on every edit. `user response` clears automatically once the reporter fixes the issue.

### `docs/ISSUE_INTAKE.md` (new)

What runs when, the full outcome table, the board setup, and where to change the rules.

## Board tracking — done, and not in this diff

An earlier revision shipped an `issue-project-tracking.yml`. **Removed.** `GITHUB_TOKEN` has no Projects v2 permission at all (verified against the workflow-syntax permission list), so that path would always have needed a PAT.

The token-free mechanism is the project's own automations, which GitHub evaluates server-side. They belong to the project, not to the person opening the issue, so they work for outside reporters — exactly the gap that left #266 and #267 off the board.

**These are now configured on project 6:**

| Automation | Filter | State |
|---|---|---|
| Auto-add to project | `is:issue is:open` on this repo | **newly enabled** |
| Item added to project | — | was already on (sets Status New) |
| Item closed | — | was already on |
| Item reopened | — | was already on |

Why `is:issue is:open` rather than plain `is:issue`: auto-add fires on new **or updated** items. With a bare `is:issue`, a long-closed issue that merely gets a comment would be pulled onto the board and stamped Status **New** — a resolved issue reappearing as fresh work. I hit this while configuring it and narrowed the filter.

Auto-add is not retroactive, so already-open issues needed adding once by hand. The repo has exactly two open issues: #1 (Renovate dashboard) was already on the board, **#267 was not** — it is now, and the "Item added" automation stamped it `Status = New` on its own, which confirms the chain end to end.

These automations are UI-only — the GraphQL API exposes `deleteProjectV2Workflow` but no create or update counterpart — so they cannot live in this repository. To see the live state:

```bash
gh api graphql -f query='
query { organization(login: "OneLiteFeatherNET") { projectV2(number: 6) {
  workflows(first: 30) { nodes { name enabled } } } } }'
```

One constraint to remember: **the org is on the Free plan → exactly one auto-add automation per project.** The single broad filter has to cover everything; Pro and Team raise this to five.

## Also found, deliberately not changed

- **The label `type: bug` does not exist.** Both the old and new bug template reference it, so it has always been silently dropped — that is why #267 only carries `status: needs triage`. Creating a label bypasses PR review, so I left it.
- **`assignees: ["OneLiteFeatherNET/antiredstoneclock-remastered-triage"]` does nothing.** Issue forms take usernames, not team slugs. No issue in the repo has an assignee. Fixing it means deciding who actually gets assigned.

## Verification

The triage script was extracted from the workflow and run against real and synthetic issue bodies:

| Case | Result |
|---|---|
| #267 (real) | unreadable log + MC 26.2 unsupported + plugin 2.8.3 outdated — all three caught |
| #230 (real) | `Game Version: 26.1.2` extracted, screenshot-instead-of-paste flagged |
| Purpur | closed, `resolution: invalid` |
| CraftBukkit/Spigot | closed, `resolution: invalid` |
| Folia | clean, no findings |
| Paper 26.1.2, fenced log | clean, no findings |
| Paper, unfenced log | formatting flagged, not closed |
| Unknown software | flagged, **not** closed |
| Fork in dropdown but Paper in log | clean — log wins |

One bug was found and fixed this way: unsupported-fork reports were getting `user response` alongside `resolution: invalid`, i.e. asking for more information on an issue being closed.

All workflow and template YAML parses.