### PR TITLE
fix: use lenient version parsing to detect the translation service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,8 @@ val supportedMinecraftVersions = listOf(
     "26.0",
     "26.1",
     "26.1.1",
-    "26.1.2"
+    "26.1.2",
+    "26.2"
 )
 allprojects {
     apply {

--- a/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModule.java
+++ b/src/main/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModule.java
@@ -47,8 +47,26 @@ public final class TranslationModule extends AbstractModule {
     }
 
     private boolean isLegacyVersion() {
-        ServerBuildInfo buildInfo = ServerBuildInfo.buildInfo();
-        Optional<Version> optionalVersion = Version.tryParse(buildInfo.minecraftVersionId());
+        return isLegacyVersion(ServerBuildInfo.buildInfo().minecraftVersionId());
+    }
+
+    /**
+     * Decides whether a server reporting {@code minecraftVersionId} needs the legacy
+     * translation service.
+     *
+     * <p>Minecraft version ids are not strict semver: releases without a patch component
+     * such as {@code "26.2"} or {@code "1.21"} are perfectly normal. They must therefore be
+     * parsed leniently, which pads the missing component to zero. Parsing them strictly
+     * returns an empty optional, which silently selects the legacy service - and that one
+     * fails with an {@code IllegalAccessError} on modern Adventure, so the plugin does not
+     * load at all.</p>
+     *
+     * @param minecraftVersionId the id the server reports, e.g. {@code "26.2"} or {@code "1.21.8"}
+     * @return {@code true} if the legacy translation service has to be used
+     * @see <a href="https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/issues/267">#267</a>
+     */
+    static boolean isLegacyVersion(String minecraftVersionId) {
+        Optional<Version> optionalVersion = Version.tryParse(minecraftVersionId, false);
         if (optionalVersion.isEmpty()) {
             return true;
         }

--- a/src/test/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModuleVersionTest.java
+++ b/src/test/java/net/onelitefeather/antiredstoneclockremastered/injection/TranslationModuleVersionTest.java
@@ -1,0 +1,87 @@
+package net.onelitefeather.antiredstoneclockremastered.injection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the translation service selection.
+ *
+ * <p>The plugin picks between the legacy and the modern translation service based on the
+ * Minecraft version the server reports. Minecraft version ids are not strict semver -
+ * {@code "26.2"} and {@code "1.21"} have no patch component - so parsing them strictly
+ * fails, the check falls through to its "cannot tell" branch and hands out the legacy
+ * service. On modern Adventure that service blows up with an {@code IllegalAccessError},
+ * taking the whole plugin down at load time.</p>
+ *
+ * @see <a href="https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/issues/267">#267</a>
+ */
+@DisplayName("TranslationModule version detection")
+class TranslationModuleVersionTest {
+
+    @Nested
+    @DisplayName("Versions without a patch component")
+    class TwoComponentVersions {
+
+        /**
+         * The exact reproduction of #267: a server on 26.2 was handed the legacy service.
+         * 26.0 and 26.1 are in supportedMinecraftVersions and fail the same way.
+         */
+        @ParameterizedTest(name = "{0} must use the modern translation service")
+        @ValueSource(strings = {"26", "26.0", "26.1", "26.2"})
+        @DisplayName("Two-component ids above 1.21.4 are not legacy")
+        void twoComponentVersionsAreNotLegacy(String minecraftVersionId) {
+            assertThat(TranslationModule.isLegacyVersion(minecraftVersionId)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Versions with a patch component")
+    class ThreeComponentVersions {
+
+        @ParameterizedTest(name = "{0} uses the modern translation service")
+        @ValueSource(strings = {"1.21.4", "1.21.8", "1.21.11", "26.1.1", "26.1.2"})
+        @DisplayName("1.21.4 and later are not legacy")
+        void modernVersionsAreNotLegacy(String minecraftVersionId) {
+            assertThat(TranslationModule.isLegacyVersion(minecraftVersionId)).isFalse();
+        }
+
+        @ParameterizedTest(name = "{0} uses the legacy translation service")
+        @ValueSource(strings = {"1.20.6", "1.21.1", "1.21.2", "1.21.3"})
+        @DisplayName("1.21.3 and earlier stay legacy")
+        void oldVersionsStayLegacy(String minecraftVersionId) {
+            assertThat(TranslationModule.isLegacyVersion(minecraftVersionId)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("1.21 stays legacy even though it has no patch component")
+        void plainOneTwentyOneStaysLegacy() {
+            // Parses to 1.21.0, which is below 1.21.4 - legacy is correct here.
+            assertThat(TranslationModule.isLegacyVersion("1.21")).isTrue();
+        }
+
+        @ParameterizedTest(name = "pre-release {0} is not legacy")
+        @ValueSource(strings = {"26.2-pre1", "1.21.5-rc1"})
+        @DisplayName("Pre-release builds of modern versions are not legacy")
+        void preReleaseBuildsAreNotLegacy(String minecraftVersionId) {
+            assertThat(TranslationModule.isLegacyVersion(minecraftVersionId)).isFalse();
+        }
+
+        @Test
+        @DisplayName("An unparseable id falls back to legacy")
+        void unparseableFallsBackToLegacy() {
+            // Better a degraded translation service than a hard failure on something
+            // we genuinely cannot interpret.
+            assertThat(TranslationModule.isLegacyVersion("not-a-version")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #267

## Reproduction

The reporter's server on Paper 26.2 could not load the plugin:

```
[Guice/ErrorInCustomProvider]: IllegalAccessError: failed to access class
MessageFormatTranslationStore from class TranslationRegistry
  at TranslationModule.provideTranslationService(TranslationModule.java:40)
```

The `IllegalAccessError` is the symptom, not the cause. One line above it, the plugin's own log says what actually went wrong:

```
[TranslationModule] Using legacy translation service
```

On 26.2 it should have picked the *modern* service.

`isLegacyVersion()` parsed the server's version id with `Version.tryParse(id)`, which is **strict** semver. Minecraft version ids are not strict semver — releases without a patch component are perfectly normal. Running the exact check against the real `java-semver` 0.10.2:

| MC version | `tryParse` | selected path |
|---|---|---|
| 1.21.11 | ok | Modern |
| 26.1.1 | ok | Modern |
| 26.1.2 | ok | Modern |
| **26.0** | **fails** | **Legacy → crash** |
| **26.1** | **fails** | **Legacy → crash** |
| **26.2** | **fails** | **Legacy → crash** |

So this is not a 26.2 problem. **Every two-component version id is affected, which means 26.0 and 26.1 are broken too** — both are in `supportedMinecraftVersions` and are published to Hangar and Modrinth. 26.1.1 and 26.1.2 only work by accident, because they happen to have three components.

Once the legacy branch is taken, `LegacyTranslationService` builds a `TranslationRegistry`, that no longer works against the Adventure shipped with modern Paper, and Guice turns the failure into a load error.

## Fix

`Version.tryParse(id, false)` — lenient parsing pads the missing component to zero, so `26.2` becomes `26.2.0` and the comparison against `1.21.4` works as intended. The comparison logic itself is unchanged.

`isLegacyVersion` now takes the version id as a parameter so it can be tested without a running server; the no-arg overload still reads it from `ServerBuildInfo`.

`26.2` is added to `supportedMinecraftVersions` — see the verification below. **If you would rather not declare 26.2 supported yet, drop that one hunk**; the fix stands on its own and still repairs 26.0 and 26.1.

## Verification

**Unit tests** — `TranslationModuleVersionTest`, 17 cases. Confirmed they actually catch the bug: with the fix reverted, exactly the affected ids fail and nothing else does.

```
Two-component ids above 1.21.4 are not legacy > "26"    FAILED
Two-component ids above 1.21.4 are not legacy > "26.0"  FAILED
Two-component ids above 1.21.4 are not legacy > "26.1"  FAILED
Two-component ids above 1.21.4 are not legacy > "26.2"  FAILED
Pre-release builds ... > "26.2-pre1"                    FAILED
"26.1.1" uses the modern translation service            PASSED
"26.1.2" uses the modern translation service            PASSED
17 tests completed, 5 failed
```

**End to end on a real server** — `./gradlew run-26.2`, Paper `26.2-111-main@f570646`, the exact build from the issue:

```
[bootstrap] Loading Paper 26.2-111-main@f570646 for Minecraft 26.2
[AntiRedstoneClock-Remastered] Loading server plugin AntiRedstoneClock-Remastered v2.8.9
[TranslationModule] Using modern translation service      <-- was "legacy" before
[AntiRedstoneClock-Remastered] Enabling AntiRedstoneClock-Remastered v2.8.9
Done (9.736s)! For help, type "help"
```

Counted in that log: `IllegalAccessError` 0, `CreationException` 0, `Error initializing plugin` 0.

The `Failed to create webhook client` error still present in that run is unrelated and pre-existing — it comes from the empty Discord webhook URL in the default config and appears in the reporter's log too. It does not stop the plugin from loading.

Full `./gradlew build` passes.

## Separate problem, not fixed here

While tracing this I confirmed the second half of the mechanism: **the shaded jar contains 410 unrelocated `net/kyori` classes**, including the whole `net.kyori.adventure.translation` package — both `TranslationRegistry` and `MessageFormatTranslationStore`. There is no `relocate(...)` anywhere in `build.gradle.kts`.

That split package across the plugin and server classloaders is what turned a wrong branch into a hard `IllegalAccessError` instead of a harmless deprecation. The modern path does not currently trip over it, so this PR does not touch it — but shipping our own copy of Paper's Adventure is a landmine worth its own issue. There is already a stale `fix/kotlin-relocation` branch dealing with Kotlin and OkHttp relocation, which is the same class of problem.