### PR TITLE
fix(ci): drop invalid platform version and allow re-publishing a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,30 @@
 name: Release Please
+
+# Two ways in:
+#
+#   push to main       Release Please collects commits into a release PR.
+#                      Merging that PR tags the version and publishes it.
+#
+#   workflow_dispatch  Re-publish a release that was already tagged. Needed
+#                      when publishing failed after the tag was created, which
+#                      otherwise leaves a release stranded with no way back -
+#                      see the 2.9.0 failure, where Hangar rejected an invalid
+#                      platform version and the JAR never reached the release.
+
 "on":
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g. v2.9.0"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to build from. Defaults to the tag itself. Point this at main when the tagged commit is what broke publishing."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -10,6 +32,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write # to create the tag and the GitHub release
@@ -29,45 +52,76 @@ jobs:
   publish:
     name: Build & Publish Release
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    # always() because release-please is skipped on workflow_dispatch, and a
+    # skipped dependency would otherwise skip this job too.
+    if: >-
+      always() &&
+      (needs.release-please.outputs.release_created == 'true' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write # to upload assets to the GitHub release
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release-please.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || inputs.tag) || needs.release-please.outputs.tag_name }}
+
+      - name: Resolve version
+        id: resolve
+        run: |
+          version="${TAG_NAME#v}"
+          declared="$(sed -n 's/^version = "\([^"]*\)".*/\1/p' build.gradle.kts)"
+          if [ "$version" != "$declared" ]; then
+            echo "::error::Tag $TAG_NAME expects version $version, but build.gradle.kts declares $declared. Refusing to publish mismatched artifacts."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 24
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-      - name: Build & Publish
-        env:
-          HANGAR_SECRET: ${{ secrets.HANGAR_KEY }}
-          MODRINTH_TOKEN: ${{ secrets.MODRINTH_KEY }}
-        run: ./gradlew check shadowJar publishAllPublicationsToHangar modrinth cyclonedxBom
+
+      - name: Build
+        run: ./gradlew check shadowJar cyclonedxBom
+
+      # Deliberately before the platform uploads. Hangar and Modrinth reject
+      # versions for reasons outside this repository's control; when that
+      # happens the artifact should still be attached to the GitHub release
+      # rather than lost with the failed run.
       - name: Upload JAR to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "$TAG_NAME" build/libs/AntiRedstoneClock-Remastered-*.jar --clobber
+
+      - name: Publish to Hangar and Modrinth
+        env:
+          HANGAR_SECRET: ${{ secrets.HANGAR_KEY }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_KEY }}
+        run: ./gradlew publishAllPublicationsToHangar modrinth
+
       - name: Upload BOM to Dependency-Track
         uses: DependencyTrack/gh-upload-sbom@v4
         with:
           serverhostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
           projectname: "AntiRedstoneClock-Remastered"
-          projectversion: ${{ needs.release-please.outputs.version }}
+          projectversion: ${{ steps.resolve.outputs.version }}
           projecttags: 'bukkit,paper,plugin'
           bomfilename: "build/reports/cyclonedx/bom.xml"
           autocreate: true
           parent: '682857a9-0cd2-4ffd-a2b3-098eeba5ab74'
+
       - name: Upload build reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,6 @@ val supportedMinecraftVersions = listOf(
     "1.21.9",
     "1.21.10",
     "1.21.11",
-    "26.0",
     "26.1",
     "26.1.1",
     "26.1.2",


### PR DESCRIPTION
The 2.9.0 release is currently broken. This fixes the cause and adds the missing way to recover.

## What happened

```
> Task :publishAntiRedstoneClock-RemasteredPublicationToHangar FAILED
> Error uploading version, returned 400: Invalid version: 26.0
```

`26.0` is not a Minecraft version that ever shipped, and both platforms reject it. Checked against the live lists rather than guessed:

| Source | 26.x versions accepted |
|---|---|
| `hangar.papermc.io/api/v1/platforms/PAPER/versions` | 26.1, 26.1.1, 26.1.2, 26.2 |
| `api.modrinth.com/v2/tag/game_version` | same — no 26.0 |

Every other entry in `supportedMinecraftVersions` is valid on both. `26.0` is the only bad one.

## The damage is wider than Hangar

The publish step ran `./gradlew check shadowJar publishAllPublicationsToHangar modrinth cyclonedxBom` as a single command, with Hangar first. When Hangar rejected the version, everything after it never ran:

| Target | State |
|---|---|
| Git tag `v2.9.0` | created |
| GitHub release `v2.9.0` | created, **0 assets** — the JAR was never attached |
| Hangar | not published |
| Modrinth | not published |
| Dependency-Track SBOM | not uploaded |

And there was no way back: the `publish` job only runs when release-please creates a release, so once the tag existed, a failed publish was unrecoverable without cutting a throwaway version.

## Changes

**1. `26.0` removed from `supportedMinecraftVersions`.** Also removes the `run-26.0` / `run-folia-26.0` tasks, which could never have worked either — Paper has no such build.

**2. The JAR is uploaded to the GitHub release *before* the platform uploads.** Hangar and Modrinth reject versions for reasons outside this repository's control. When that happens the artifact should still land on the release instead of dying with the run.

**3. The workflow accepts `workflow_dispatch`,** so an already-tagged release can be published again:

- `tag` (required) — the release tag to publish, e.g. `v2.9.0`
- `ref` (optional) — what to build from, defaults to the tag. Point it at `main` when the tagged commit is exactly what broke publishing, which is the case here.

A guard compares the tag against `version` in `build.gradle.kts` and refuses to publish if they disagree, so `ref` cannot be used to accidentally ship 2.9.1 code under the v2.9.0 tag. Verified both directions:

```
v2.9.0 -> ok (version 2.9.0)
v2.9.1 -> abort (tag=2.9.1, build=2.9.0)
```

`release-please` is now gated on `github.event_name == 'push'` so a manual dispatch does not touch the release PR, and `publish` uses `always()` so it is not skipped along with it.

## Recovering 2.9.0 after this merges

`main` still declares `version = "2.9.0"`, so building from `main` produces exactly the 2.9.0 artifact — now with a platform list Hangar accepts:

```
gh workflow run release-please.yml -f tag=v2.9.0 -f ref=main
```

That attaches the JAR to the existing v2.9.0 release, publishes to Hangar and Modrinth, and uploads the SBOM. No new version number, no moved tag.

This has to happen before the next release PR merges — once release-please bumps `main` to 2.9.1, the version guard will correctly refuse the v2.9.0 dispatch.

## Verification

`./gradlew build` passes. The generated run tasks are now `run-26.1`, `run-26.1.1`, `run-26.1.2`, `run-26.2` — no more `run-26.0`.