### PR TITLE
ci: gate releases on a vulnerability scan before anything goes public

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,8 +49,9 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
-    name: Build & Publish Release
+  # Builds, publishes nothing. Everything public waits behind security-gate.
+  build:
+    name: Build Release Artifacts
     needs: release-please
     # always() because release-please is skipped on workflow_dispatch, and a
     # skipped dependency would otherwise skip this job too.
@@ -60,9 +61,13 @@ jobs:
        github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to upload assets to the GitHub release
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      ref: ${{ steps.resolve.outputs.ref }}
     env:
       TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release-please.outputs.tag_name }}
+      BUILD_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.ref || inputs.tag) || needs.release-please.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -79,6 +84,7 @@ jobs:
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "ref=$BUILD_REF" >> "$GITHUB_OUTPUT"
 
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
@@ -95,32 +101,21 @@ jobs:
       - name: Build
         run: ./gradlew check shadowJar cyclonedxBom
 
-      # Deliberately before the platform uploads. Hangar and Modrinth reject
-      # versions for reasons outside this repository's control; when that
-      # happens the artifact should still be attached to the GitHub release
-      # rather than lost with the failed run.
-      - name: Upload JAR to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$TAG_NAME" build/libs/AntiRedstoneClock-Remastered-*.jar --clobber
-
-      - name: Publish to Hangar and Modrinth
-        env:
-          HANGAR_SECRET: ${{ secrets.HANGAR_KEY }}
-          MODRINTH_TOKEN: ${{ secrets.MODRINTH_KEY }}
-        run: ./gradlew publishAllPublicationsToHangar modrinth
-
-      - name: Upload BOM to Dependency-Track
-        uses: DependencyTrack/gh-upload-sbom@v4
+      - name: Upload plugin JAR
+        uses: actions/upload-artifact@v7
         with:
-          serverhostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
-          apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
-          projectname: "AntiRedstoneClock-Remastered"
-          projectversion: ${{ steps.resolve.outputs.version }}
-          projecttags: 'bukkit,paper,plugin'
-          bomfilename: "build/reports/cyclonedx/bom.xml"
-          autocreate: true
-          parent: '682857a9-0cd2-4ffd-a2b3-098eeba5ab74'
+          name: plugin-jar
+          path: build/libs/AntiRedstoneClock-Remastered-*.jar
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: build/reports/cyclonedx/bom.xml
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload build reports
         if: always()
@@ -130,3 +125,91 @@ jobs:
           path: build/reports/**
           if-no-files-found: ignore
           retention-days: 14
+
+  # The point of no return. Everything below this job is public, so a HIGH or
+  # CRITICAL finding in the jar we are about to ship stops the release here.
+  # Scans the built artifact, not the source tree: for a shaded jar that is the
+  # only target that sees what actually ships.
+  security-gate:
+    name: Security Gate
+    needs: build
+    permissions:
+      contents: read
+      security-events: write # SARIF upload to code scanning
+    uses: OneLiteFeatherNET/workflows/.github/workflows/security-scan.yml@v2.6.0
+    with:
+      scan-type: rootfs
+      artifact-name: plugin-jar
+      severity: "CRITICAL,HIGH"
+      fail-on-findings: true
+    secrets: inherit
+
+  publish:
+    name: Publish Release
+    needs: [release-please, build, security-gate]
+    # No always() here - a failed gate must stop the release, and always()
+    # would run this job anyway.
+    if: >-
+      !cancelled() &&
+      needs.security-gate.result == 'success' &&
+      (needs.release-please.outputs.release_created == 'true' ||
+       github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload assets to the GitHub release
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release-please.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.build.outputs.ref }}
+
+      - name: Download plugin JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-jar
+          path: build/libs
+
+      # Deliberately before the platform uploads. Hangar and Modrinth reject
+      # versions for reasons outside this repository's control; when that
+      # happens the artifact should still be attached to the GitHub release
+      # rather than lost with the failed run.
+      - name: Upload JAR to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$TAG_NAME" build/libs/AntiRedstoneClock-Remastered-*.jar --clobber
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 24
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Publish to Hangar and Modrinth
+        env:
+          HANGAR_SECRET: ${{ secrets.HANGAR_KEY }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_KEY }}
+        run: ./gradlew publishAllPublicationsToHangar modrinth
+
+  # Separate job so Dependency-Track being down, or rejecting the API key,
+  # cannot take the release with it. 2.9.0 is why: the SBOM upload sat inside
+  # the publish job and one rejected platform version cost the JAR, both
+  # platform releases and the SBOM at once.
+  sbom:
+    name: Publish SBOM
+    needs: [build, publish]
+    uses: OneLiteFeatherNET/workflows/.github/workflows/sbom-publish.yml@v2.6.0
+    with:
+      project-name: "AntiRedstoneClock-Remastered"
+      project-version: ${{ needs.build.outputs.version }}
+      project-tags: "bukkit,paper,plugin"
+      parent-uuid: "682857a9-0cd2-4ffd-a2b3-098eeba5ab74"
+      # The CycloneDX Gradle plugin resolves the dependency graph better than
+      # an external scanner, so hand it the artifact the build produced.
+      artifact-name: "sbom"
+      sbom-path: "bom.xml"
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,36 @@
+name: Security
+
+# Dependency and secret scanning via the shared Trivy workflow. Complements
+# CodeQL rather than duplicating it: CodeQL analyses our own code, Trivy looks
+# at what we pull in and at anything credential-shaped that slipped into the
+# tree.
+#
+# No pull_request trigger on purpose. Fork pull requests get a read-only token,
+# so the SARIF upload to code scanning would fail for exactly the contributions
+# that need review most. Scanning main plus a weekly sweep also catches CVEs
+# published against code that has not changed - which is the majority of them.
+
+"on":
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Trivy
+    permissions:
+      contents: read
+      security-events: write # to upload the SARIF report to code scanning
+    uses: OneLiteFeatherNET/workflows/.github/workflows/security-scan.yml@v2.6.0
+    with:
+      scan-type: fs
+      severity: "CRITICAL,HIGH"
+      # Report-only for now. Flip once the backlog is at zero, otherwise the
+      # first unrelated CVE blocks main.
+      fail-on-findings: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,16 @@ allprojects {
 }
 
 dependencies {
+    constraints {
+        // CVE-2023-5072 (HIGH): org.json below 20231013 can be driven into a
+        // parser denial of service. It reaches the shaded jar transitively via
+        // club.minnced:discord-webhooks, which still resolves 20230618.
+        // Found by the Trivy gate in .github/workflows/release-please.yml.
+        implementation("org.json:json:20231013") {
+            because("CVE-2023-5072 in the version discord-webhooks pulls in")
+        }
+    }
+
     implementation(libs.bstats)
     implementation(libs.cloud.command.paper)
     implementation(libs.cloud.command.extras)


### PR DESCRIPTION
Depends on OneLiteFeatherNET/workflows#23 — **do not merge before that is released as `v2.6.0`**, the two `uses:` pins point at that tag.

## The pipeline now breaks before anything is public

```
release-please → build → security-gate → publish → sbom
```

`build` produces the jar and the SBOM and publishes nothing. `security-gate` scans the jar that is about to ship and fails on CRITICAL or HIGH. `publish` runs only when the gate is green, so a vulnerable build can no longer reach the GitHub release, Hangar or Modrinth.

`publish` deliberately does **not** use `always()` — that would have run it regardless of a failed gate. It uses `!cancelled() && needs.security-gate.result == 'success' && (…)` instead.

## The gate scans the artifact, not the source tree

This is the part that would have been easy to get wrong. Measured on this repository:

| Scan | Packages detected | Findings |
|---|---|---|
| `trivy fs` on the source tree | 0 real (only stray jacoco `pom.xml` from build caches) | 0 |
| `trivy fs` on the shaded jar | 0 | 0 |
| **`trivy rootfs` on the shaded jar** | **12** | **1 HIGH** |

A gate on either `fs` variant would have reported green while checking nothing at all. Gradle without a `gradle.lockfile` gives `fs` nothing to read, and Trivy's `fs` scanner does not look inside JARs.

## That one HIGH is real, and is fixed here

`CVE-2023-5072` — `org.json` below `20231013` can be driven into a parser denial of service. It reaches our shaded jar transitively:

```
org.json:json:20230618
\--- club.minnced:discord-webhooks:0.8.4
```

Fixed with a dependency constraint forcing `20231013`. Verified end to end:

```
before:  12 packages, 1 HIGH (CVE-2023-5072, org.json 20230618)
after :  org.json:json:20230618 -> 20231013
         12 packages, 0 findings
```

Without this the new gate would block every single release on day one.

## SBOM upload moves out of the release job

The Dependency-Track upload now runs as its own job via the shared `sbom-publish.yml`, fed the CycloneDX artifact the build produced. An unreachable server or a rejected API key can no longer take the release with it — which is exactly what happened to 2.9.0, where one rejected platform version cost the JAR, both platform releases and the SBOM at once.

Note this does **not** fix the `403` that 2.9.0's SBOM upload hit. That is a Dependency-Track API key permission: with `autocreate` on, the key's team needs `PROJECT_CREATION_UPLOAD` in addition to `BOM_UPLOAD`. Still needs doing on the server side.

## `security.yml` — continuous monitoring on top

The gate only sees a release at the moment it is cut. Most CVEs are published against code that has not changed since, so `security.yml` scans `main` plus a weekly sweep, report-only, with findings in code scanning.

No `pull_request` trigger on purpose: fork PRs get a read-only token, so the SARIF upload would fail for exactly the contributions that most need review.

## Cost

`publish` re-runs Gradle for the Hangar and Modrinth tasks, since those are Gradle tasks and cannot consume a downloaded jar. With the `setup-gradle` cache that is a cache-hit rebuild, and it buys the guarantee that nothing is published before the gate.