### PR TITLE
chore(ci): adopt shared workflows and central Renovate preset

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,101 +1,19 @@
 name: Build PR
-on: [pull_request]
+
+on:
+  pull_request:
+
 permissions:
-  contents: write
+  contents: read
   checks: write
-  issues: write
   pull-requests: write
+
 jobs:
-  build_pr:
-    if: github.repository_owner == 'OneLiteFeatherNET'
-    name: Build Pull Request Branch
-    runs-on: ${{ matrix.os }}
-    env:
-      ONELITEFEATHER_MAVEN_USERNAME: ${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
-      ONELITEFEATHER_MAVEN_PASSWORD: ${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 24
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Build on ${{ matrix.os }}
-        run: ./gradlew clean build test
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() && matrix.os == 'ubuntu-latest'
-        with:
-          files: "**/build/test-results/test/TEST-*.xml"
-          check_name: "Test Results"
-          comment_title: "Unit Test Results"
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v7
-        if: always() && matrix.os == 'ubuntu-latest'
-        with:
-          name: test-report
-          path: build/reports/tests/test/
-      - name: Upload Coverage Reports
-        uses: actions/upload-artifact@v7
-        if: always() && matrix.os == 'ubuntu-latest'
-        with:
-          name: coverage-report
-          path: build/reports/jacoco/test/
-  upload_jar_and_comment:
-    name: Upload JAR and comment PR
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    needs: build_pr
-    if: contains(github.event.pull_request.labels.*.name, 'publish-pr')
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 24
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Build
-        run: ./gradlew clean build test
-      - name: Upload JAR for PR
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-jar
-          path: build/libs/*.jar
-      - name: Get JAR Artifact Download URL
-        id: get-artifact-url
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const runId = context.runId;
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId
-            });
-            const jarArtifact = artifacts.data.artifacts.find(a => a.name === 'pr-jar');
-            if (!jarArtifact) throw new Error('pr-jar artifact not found');
-            const url = jarArtifact.archive_download_url;
-            core.setOutput('jar_url', url);
-      - name: Create or Update PR Comment with direct JAR download link
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :package: A new JAR build is available!
-            [Download the JAR directly](${{ steps.get-artifact-url.outputs.jar_url }})
-            
-            Note: The download link is valid for a limited time and requires GitHub authentication.
-          edit-mode: replace
-          comment-id: pr-jar-artifact-link
+  build:
+    # Shared org build: Temurin toolchain, 3-OS matrix, tests and coverage.
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@v2.8.1
+    with:
+      java-version: "24"
+      java-distribution: "temurin"
+      run-tests: true
+    secrets: inherit

--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -2,13 +2,9 @@ name: Close invalid PRs
 
 on:
   pull_request_target:
-    types: [ opened ]
+    types: [opened]
 
 jobs:
-  run:
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name && github.head_ref == 'main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: superbrothers/close-pull-request@v3
-        with:
-          comment: "Please do not open pull requests from the `main` branch, create a new branch instead."
+  close:
+    uses: OneLiteFeatherNET/workflows/.github/workflows/close-invalid-prs.yml@v2.8.1
+    secrets: inherit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,24 +6,66 @@
   "bootstrap-sha": "38c50b8336be3eb87a0512b6ae3ced117b0c5a3f",
   "pull-request-header": "",
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "refactor", "section": "Code Refactoring" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "style", "section": "Styles", "hidden": true },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "build", "section": "Build System", "hidden": true },
-    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
       "package-name": "AntiRedstoneClock-Remastered",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "generic", "path": "build.gradle.kts" }
+        {
+          "type": "generic",
+          "path": "build.gradle.kts"
+        }
       ]
     }
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/antiredstone-remastered-maintainers)"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/antiredstone-remastered-maintainers)",
+    "github>OneLiteFeatherNET/renovate:paper"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/antiredstone-remastered-maintainers)",
-    "github>OneLiteFeatherNET/renovate:paper"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/antiredstone-remastered-maintainers)"
   ]
 }


### PR DESCRIPTION
## What

Brings this repository onto the OneLiteFeather standard CI, release and dependency setup.

**CI, security and dependencies**

- renovate.json -> central preset (antiredstone-remastered-maintainers)
- build-pr.yml (gradle-build-pr, Java 24, run-tests: true) (replaced hand-rolled job)
- close_invalid_prs.yml (replaced hand-rolled job)
- pinned reusable workflows to v2.8.1 (close_invalid_prs.yml,build-pr.yml)

**Release automation and PR hygiene**

- bereits vollständig konform

**Version anchoring and Renovate presets**

- renovate flavor restored: paper
- extra-files now points at build.gradle.kts

## Why

One shared setup per concern instead of a hand-maintained copy per repository:

- **Reusable workflows** (`OneLiteFeatherNET/workflows`) are pinned to a full SemVer tag, so a fix
  in the shared catalogue reaches this repository through a Renovate PR.
- **Central Renovate preset** brings the shared schedule, automerge and labelling rules and assigns
  the maintainer team as reviewer, instead of a per-repository config that drifts.
- **Security gate**: Trivy scans for vulnerabilities and secrets and reports into GitHub code
  scanning, plus a CycloneDX SBOM on every run. Report-only, so adopting it does not turn CI red on
  day one.
- **Release Please in simple mode** turns Conventional Commits into a release PR; merging it tags
  the version and cuts the release. Simple mode deliberately does not rewrite language version
  files, which keeps this change limited to release plumbing.
- **A CycloneDX SBOM is attached to every GitHub release**, so each shipped version carries its own
  dependency inventory.
- **The Renovate platform preset** (`:minestom` / `:paper`) is what teaches Renovate the
  date-based Minestom scheme and Paper's `X.Y.Z-<mc-version>` scheme; without it those two get
  parsed as plain SemVer and updated wrongly.
- **The version lives in `build.gradle.kts` behind `// x-release-please-version`**, so a release
  changes exactly one line in one file instead of a properties file the build has to parse.
- **PR linting** enforces Conventional Commits on the PR title and on every commit - without it
  release-please silently fails to bump the version or drops the commit from the changelog.

Everything a release needs is chained into the release-please workflow run on purpose: release-please
tags with `GITHUB_TOKEN`, and a tag pushed that way does **not** start a separate
`on: push: tags` workflow.