### PR TITLE
docs: point the README at the published documentation site

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -12,7 +12,7 @@ body:
       options:
         - label: I am running the latest version of AntiRedstoneClock-Remastered from [Hangar](https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered) or [Modrinth](https://modrinth.com/plugin/AntiRedstoneClock-Remastered).
           required: true
-        - label: I am running a Minecraft version that is listed as supported in the [supported versions](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/blob/main/docs/reference/supported-versions.md).
+        - label: I am running a Minecraft version that is listed as supported in the [supported versions](https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/reference/supported-versions/).
           required: true
         - label: I searched the open and closed issues and this is not a duplicate.
           required: true
@@ -25,7 +25,7 @@ body:
       label: Server software
       description: |
         We support Paper and Folia. Paper forks, Spigot, CraftBukkit and hybrid servers are not supported -
-        see [Scope and non-goals](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/blob/main/docs/explanation/scope-and-non-goals.md).
+        see [Scope and non-goals](https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/explanation/scope-and-non-goals/).
         Reports for unsupported software are closed automatically.
       options:
         - Paper

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,11 @@ Ask us anything on [Discord](https://discord.onelitefeather.net).
 - [docs/development/](docs/development/) covers the dependency injection setup, the testing
   guide and how issues are triaged.
 
-Documentation for users lives in [docs/](docs/index.md). See
-[Writing documentation](docs/development/documentation.md) for how it is organised and which
-pages have to be updated when you change a config key, a command or a permission.
+Documentation for users lives in [docs/](docs/index.md) and is published to
+<https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/> from `main`. See
+[Writing documentation](docs/development/documentation.md) for how it is organised, how to
+preview the site locally, and which pages have to be updated when you change a config key, a
+command or a permission.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -13,25 +13,28 @@ else. It works with PlotSquared and WorldGuard when they are installed, and supp
 
 ## Documentation
 
-**[📖 docs/index.md](docs/index.md)** — start here.
+**[📖 Read the documentation][docs]** — it has search.
 
-- New to the plugin? [Detect your first redstone clock](docs/tutorial/detect-your-first-clock.md)
-- Setting it up? The [how-to guides](docs/how-to/) cover Discord alerts, ignoring a world,
-  region exceptions, and reporting clocks without breaking them.
-- Looking up a key, a command or a permission? See the [reference](docs/reference/).
-- Wondering how it decides what a clock is? See the [background pages](docs/explanation/).
+- New to the plugin? [Detect your first redstone clock][tutorial]
+- Setting it up? The how-to guides cover [Discord alerts][discord-alerts], [ignoring a
+  world][ignore-world], [region exceptions][regions] and [reporting clocks without breaking
+  them][report-only].
+- Looking up a value? [Configuration][config] · [Commands][commands] · [Permissions][perms]
+- Wondering how it decides what a clock is? [How detection works][detection]
+
+The pages are written in [`docs/`](docs/) and published from `main` on every change.
 
 ## Download
 
 - [Hangar](https://hangar.papermc.io/OneLiteFeather/AntiRedstoneClock-Remastered)
 - [Modrinth](https://modrinth.com/plugin/AntiRedstoneClock-Remastered)
 
-Requires Java 25 and a [supported Minecraft version](docs/reference/supported-versions.md).
+Requires Java 25 and a [supported Minecraft version][versions].
 
 ## Get help
 
 - [Open an issue](https://github.com/OneLiteFeatherNET/AntiRedstoneClock-Remastered/issues) —
-  please attach a [debug log](docs/how-to/produce-a-debug-log-for-a-bug-report.md)
+  please attach a [debug log][debug-log]
 - [Discord](https://discord.onelitefeather.net)
 
 ## Contributing
@@ -41,3 +44,16 @@ are cut.
 
 This plugin is inspired by [Trafalcraft's antiRedstoneClock](https://gitlab.com/Trafalcraft/antiRedstoneClock);
 the code was re-created from scratch. Licensed under the terms in [LICENSE](LICENSE).
+
+[docs]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/
+[tutorial]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/tutorial/detect-your-first-clock/
+[discord-alerts]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/how-to/send-alerts-to-discord/
+[ignore-world]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/how-to/exclude-a-world-from-detection/
+[regions]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/how-to/allow-redstone-clocks-in-a-region/
+[report-only]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/how-to/report-clocks-without-breaking-them/
+[debug-log]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/how-to/produce-a-debug-log-for-a-bug-report/
+[config]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/reference/configuration/
+[commands]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/reference/commands/
+[perms]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/reference/permissions/
+[versions]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/reference/supported-versions/
+[detection]: https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/explanation/how-detection-works/


### PR DESCRIPTION
## Proposed changes

Since #311 the documentation is published at <https://onelitefeathernet.github.io/AntiRedstoneClock-Remastered/>, but the README still pointed readers at the raw Markdown files in `docs/`.

Raw Markdown on GitHub is the worse of the two for someone setting the plugin up: no search across thirty config keys, no navigation between the four sections, and a reader who lands on a reference page has no way through to the how-to that uses it.

- README, `CONTRIBUTING.md` and the bug report template now link to the rendered site.
- The README uses reference-style links, so the raw file stays readable in a terminal instead of carrying twelve 90-character URLs inline.
- Every link was checked for HTTP 200 against the live site.

`docs/` is still named in the README and CONTRIBUTING as the place the pages are written — that is where a contributor edits them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Two related things you may want to decide separately:

- The repository's **homepage field** still points at `onelitefeather.net`. Pointing it at the docs site would put the link in the sidebar on GitHub, where people look first. That is a repository setting, so I left it alone.
- If a **custom domain** under `onelitefeather.net` is planned for the docs, these links and `site_url` in `mkdocs.yml` change with it. Worth settling before the URL spreads to Hangar and Modrinth.
