### PR TITLE
docs: prepare GitBook Git Sync from the docs directory

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,8 @@
+# GitBook Git Sync reads the documentation straight out of docs/.
+# The navigation is docs/SUMMARY.md; a page that is not listed there is not part
+# of the space. See docs/development/documentation.md.
+root: ./docs/
+
+structure:
+  readme: index.md
+  summary: SUMMARY.md

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,34 @@
+# Table of contents
+
+* [Overview](index.md)
+
+## Getting started
+
+* [Detect your first redstone clock](tutorial/detect-your-first-clock.md)
+
+## How-to guides
+
+* [Send alerts to Discord](how-to/send-alerts-to-discord.md)
+* [Notify staff in game](how-to/notify-staff-in-game.md)
+* [Exclude a world from detection](how-to/exclude-a-world-from-detection.md)
+* [Allow redstone clocks in a region](how-to/allow-redstone-clocks-in-a-region.md)
+* [Report clocks without breaking them](how-to/report-clocks-without-breaking-them.md)
+* [Stop warning signs from being placed](how-to/stop-warning-signs-from-being-placed.md)
+* [Change the plugin language](how-to/change-the-plugin-language.md)
+* [Tune how quickly a clock is detected](how-to/tune-how-quickly-a-clock-is-detected.md)
+* [Produce a debug log for a bug report](how-to/produce-a-debug-log-for-a-bug-report.md)
+
+## Reference
+
+* [Configuration](reference/configuration.md)
+* [Commands](reference/commands.md)
+* [Permissions](reference/permissions.md)
+* [Supported versions](reference/supported-versions.md)
+* [Debug log files](reference/debug-log-files.md)
+
+## Background
+
+* [How detection works](explanation/how-detection-works.md)
+* [What happens to a detected clock](explanation/what-happens-to-a-detected-clock.md)
+* [Static and dynamic tracking](explanation/static-and-dynamic-tracking.md)
+* [Scope and non-goals](explanation/scope-and-non-goals.md)

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -61,3 +61,37 @@ and it has to be added to `docs/index.md` as well — the index is what readers 
 
 `docs/development/` is excluded from the published site through `exclude_docs`. It stays
 readable on GitHub, which is where the people who need it already are.
+
+## Adding a page
+
+A new page has to be registered in **three** places, and forgetting one of them is the usual
+mistake:
+
+1. The file itself, in the directory of its quadrant.
+2. `nav:` in `mkdocs.yml` — the MkDocs build runs with `--strict` and fails on a page that is
+   missing from it, so this one catches itself.
+3. `docs/SUMMARY.md` — the GitBook navigation. **Nothing checks this one.** A page that is not
+   listed there is not part of the GitBook space, and a rename that only happens in the file
+   system silently drops the page out of the navigation while leaving it reachable by URL.
+
+Also add it to `docs/index.md`, which is what readers actually land on.
+
+## GitBook
+
+`.gitbook.yaml` in the repository root points GitBook Git Sync at `docs/`, with `index.md` as
+the landing page and `SUMMARY.md` as the navigation. The four quadrant directories become the
+four page groups.
+
+Two things about Git Sync are worth knowing before editing anything in the GitBook editor:
+
+- **It is bidirectional.** Edits made in GitBook are committed back to the branch the space is
+  connected to. Those commits do not pass through a pull request, so they are not seen by
+  `pr-lint` and not reviewed.
+- **It has no link check.** The `--strict` MkDocs build is what catches a dead link between two
+  pages, and it only runs on pull requests. A link broken through the GitBook editor is not
+  caught by anything until a reader hits it.
+
+While both targets exist, `nav:` in `mkdocs.yml` and `docs/SUMMARY.md` describe the same
+structure twice and have to be changed together. That duplication is the reason to settle on
+one of the two rather than running both indefinitely.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,11 @@ edit_uri: edit/main/docs/
 copyright: OneLiteFeatherNET
 
 # The maintainer record is not part of the user documentation. It stays readable
-# on GitHub and is linked from CONTRIBUTING.md.
+# on GitHub and is linked from CONTRIBUTING.md. SUMMARY.md is the GitBook
+# navigation and has no meaning here.
 exclude_docs: |
   development/
+  SUMMARY.md
 
 theme:
   name: material


### PR DESCRIPTION
## Proposed changes

OneLiteFeather publishes documentation with GitBook elsewhere, so this repository should be reachable the same way.

GitBook Git Sync can read `docs/` exactly as it stands — no restructuring needed, because the four quadrant directories map directly onto the four page groups GitBook renders.

- **`.gitbook.yaml`** in the repository root: `root: ./docs/`, `index.md` as the landing page, `SUMMARY.md` as the navigation.
- **`docs/SUMMARY.md`**: the navigation, with the same reader-facing group names used everywhere else — getting started, how-to guides, reference, background. `docs/development/` is deliberately not listed; it is the maintainer record, not part of the space.

Both files were checked against the tree: all 20 pages are listed, no entry points at a file that does not exist, and the listing matches the MkDocs `nav` exactly.

## Nothing is switched off

The MkDocs workflow keeps building and deploying, so the GitBook space can be connected and reviewed before deciding which of the two stays. `SUMMARY.md` is excluded from the MkDocs build, where it has no meaning — verified that `mkdocs build --strict` still passes and that no `SUMMARY` page appears in the generated site.

## What running both costs

`nav:` in `mkdocs.yml` and `docs/SUMMARY.md` describe the same structure twice and have to be changed together. Only the MkDocs one fails the build when it is forgotten. That duplication is written down in `docs/development/documentation.md`, and it is the reason to settle on one target rather than running both indefinitely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Next steps, on your side

1. Create the GitBook space and connect Git Sync to this repository. Pick the branch it syncs with deliberately — **Git Sync is bidirectional**: edits made in the GitBook editor are committed straight back to that branch, bypassing `pr-lint` and review. A dedicated branch is the safer choice if that matters.
2. Check the GitBook plan for the organisation before the URL goes into README, Hangar and Modrinth.
3. Once the space looks right, say so and I will do the switch in one pass: remove the MkDocs workflow and Pages deployment, and repoint README, `CONTRIBUTING.md` and the issue template at the GitBook URL. Worth deciding then whether to keep the MkDocs build as a `--strict` link checker on pull requests — GitBook has no equivalent, and after the reference generator was dropped it would otherwise be the only automated check left on the documentation.
